### PR TITLE
fix null reference when autostart is false without building container

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/Unity/LifetimeScope.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/LifetimeScope.cs
@@ -138,7 +138,7 @@ namespace VContainer.Unity
         void OnDestroy()
         {
             disposable.Dispose();
-            Container.Dispose();
+            Container?.Dispose();
         }
 
         public void Build()


### PR DESCRIPTION
autostartがfalseの状態で再生後に、ビルドを実行しないで終了すると
null reference exceptionが発生していたので修正しました。