### PR TITLE
Add register aliases : `RegisterEntryPoint`, `RegisterComponent`

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,8 +582,6 @@ class OtherClass
 
 **Register from MonoInstaller's `[SerializeField]`**
 
-Also use `RegisterInstance()`.
-
 ```csharp
 [SerializeField]
 YourBehaviour yourBehaviour;

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ![](docs/unity_performance_test_result.png)
 
-- This benchmark was run by [Performance Testing Extension for Unity Test Runner](https://docs.unity3d.com/Packages/com.unity.test-framework.performance@1.0/manual/index.html).  Test cases is [here](./VContainer.Benchmark).
+- This benchmark was run by [Performance Testing Extension for Unity Test Runner](https://docs.unity3d.com/Packages/com.unity.test-framework.performance@1.0/manual/index.html).  Test cases is [here](VContainer.Benchmark).
 - :warning: This benchmark does not use Zenject's Reflection baking.
   - Currently, VContainer does not support pre-build IL weaving or C# code generation optimizations, but it is planned for a future version.
   - VContainer does all type-analyze in Container Build phase. To reduce main thread blokcing time, you can consider [Async Contaienr Build](#async-contaienr-build).
@@ -42,7 +42,7 @@ Following is a deep profiler Unity result sample.
 ## What is DI ?
 
 DI (Dependency Injection) is a general technique in OOP that all about removing uninteresting dependencies from your code.  
-It brings testability, maintainability, extensibility or any kind of exchangeability to your object graph.  
+It brings testability, maintainability, extensibility or any kind of exchangeability to your object graph.
 
 In all programming paradigms, the basic design is, weak module coupling and strong module cohesion.
 As you know, OOP(Object Oriented Programming) does it through objects.
@@ -79,7 +79,7 @@ Further reading:
   - Or add this to your `Package/manifest.json`
     - `"jp.hadashikick.vcontainer": "https://github.com/hadashiA/VContainer.git?path=VContainer/Assets/VContainer"`
 - unitypackage
-  - The releases page provides downloadable .unitypackage files.
+  - The [releases](https://github.com/hadashiA/VContainer/releases) page provides downloadable .unitypackage files.
 
 ## Getting Started
 
@@ -138,7 +138,7 @@ namespace MyGame
 }
 ```
 
-Note:  
+Note:
 - VContainer always required a `Lifetime` argument explicitly. This gives us transparency and consistency.
 
 **3. Create LifetimeScope**
@@ -224,19 +224,11 @@ As such, it's a good practice to keep any side effect entry points through the m
 We should register this as `ITickable` marker.
 
 ```csharp
-builder.Register<GamePresenter>(Lifetime.Singleton)
-    .As<ITickable>();
+builder.RegisterEntryPoint<GamePresenter>(Lifetime.Singleton)    
 ```
 
-Marker interface is a bit noisy to specify, so we will automate it below.
-
-```csharp
-builder.Register<GamePresenter>(Lifetime.Singleton)
-    .AsImplementedInterfaces();
-```
-
-
-**Recommendation:**
+Note:
+- `RegisterEntryPoint<GamePresenter>` is an alias to register interfaces related to Unity's PlayerLoop event. ( Simular to `Register<GamePresenter>(Lifetime.Singleton).As<ITickable>()`)
 - Registering lifecycle events without relying on MonoBehaciour facilitates decupling of domain logic and presentation !
 
 
@@ -435,7 +427,7 @@ class ClassA
 } 
 ```
 
-**Register as multiple Interface**
+#### Register as multiple Interface
 
 ```csharp
 builder.Register<ServiceA>(Lifetime.Singleton)
@@ -456,7 +448,7 @@ class ClassB
 }
 ```
 
-**Register all implemented interfaces automatically**
+####  Register all implemented interfaces automatically
 
 ```csharp
 builder.Register<ServiceA>(Lifetime.Singleton)
@@ -477,7 +469,7 @@ class ClassB
 }
 ```
 
-**Register all implemented interfaces and concrete type**
+#### Register all implemented interfaces and concrete type
 
 ```csharp
 builder.Register<ServiceA>(Lifetime.Singleton)
@@ -504,6 +496,18 @@ class ClassB
 }
 ```
 
+#### Register lifecycle marker interfaces
+
+```csharp
+class GameController : IInitializable, ITickable, IDisposable { /* ... */ }
+```
+
+```csharp
+builder.RegisterEntryPoint<GameController>(Lifetime.Singleton);
+```
+
+Not that this is similar to `Register<GameController>(Lifetime.Singleton).AsImplementedInterfaces()`
+
 #### Register instance
 
 ```csharp
@@ -525,7 +529,7 @@ class ClassA
 }
 ```
 
-**Register instance as interface**
+####  Register instance as interface
 
 ```csharp
 builder.RegisterInstance<IInputPort>(serviceA);
@@ -574,7 +578,6 @@ class OtherClass
 }
 ```
 
-
 #### Register `UnityEngine.Object`
 
 **Register from MonoInstaller's `[SerializeField]`**
@@ -587,7 +590,7 @@ YourBehaviour yourBehaviour;
 
 // ...
 
-builder.RegisterInstance(yourBehaviour);
+builder.RegisterComponent(yourBehaviour);
 ```
 
 **Register from scene with `LifetimeScope`**

--- a/VContainer/Assets/VContainer/Runtime/RegistrationBuilder.cs
+++ b/VContainer/Assets/VContainer/Runtime/RegistrationBuilder.cs
@@ -15,9 +15,9 @@ namespace VContainer
 
         internal RegistrationBuilder(Type implementationType, Lifetime lifetime, List<Type> interfaceTypes = null)
         {
-            this.ImplementationType = implementationType;
-            this.InterfaceTypes = interfaceTypes;
-            this.Lifetime = lifetime;
+            ImplementationType = implementationType;
+            InterfaceTypes = interfaceTypes;
+            Lifetime = lifetime;
         }
 
         internal RegistrationBuilder(object instance)

--- a/VContainer/Assets/VContainer/Runtime/Unity/ComponentRegistrationBuilder.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/ComponentRegistrationBuilder.cs
@@ -18,6 +18,9 @@ namespace VContainer.Unity
             List<Type> interfaceTypes = null)
             : base(implementationType, lifetime, interfaceTypes)
         {
+            InterfaceTypes = InterfaceTypes ?? new List<Type>();
+            InterfaceTypes.Add(typeof(MonoBehaviour));
+            InterfaceTypes.Add(ImplementationType);
         }
 
         internal ComponentRegistrationBuilder(
@@ -25,7 +28,7 @@ namespace VContainer.Unity
             Type implementationType,
             Lifetime lifetime,
             List<Type> interfaceTypes = null)
-            : base(implementationType, lifetime, interfaceTypes)
+            : this(implementationType, lifetime, interfaceTypes)
         {
             this.prefab = prefab;
         }
@@ -35,7 +38,7 @@ namespace VContainer.Unity
             Type implementationType,
             Lifetime lifetime,
             List<Type> interfaceTypes = null)
-            : base(implementationType, lifetime, interfaceTypes)
+            : this(implementationType, lifetime, interfaceTypes)
         {
             this.gameObjectName = gameObjectName;
         }

--- a/VContainer/Assets/VContainer/Runtime/Unity/IContainerBuilderUnityExtensions.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/IContainerBuilderUnityExtensions.cs
@@ -4,9 +4,31 @@ namespace VContainer.Unity
 {
     public static class IContainerBuilderUnityExtensions
     {
+        public static RegistrationBuilder RegisterEntryPoint<T>(
+            this IContainerBuilder builder,
+            Lifetime lifetime)
+        {
+            var registrationBuilder = builder.Register<T>(lifetime);
+            if (typeof(T).IsSubclassOf(typeof(MonoBehaviour)))
+            {
+                registrationBuilder = registrationBuilder.As(typeof(MonoBehaviour));
+            }
+            return registrationBuilder.AsImplementedInterfaces();
+        }
+
+        public static RegistrationBuilder RegisterComponent(
+            this IContainerBuilder builder,
+            MonoBehaviour component)
+            => builder.RegisterInstance(component).As(typeof(MonoBehaviour), component.GetType());
+
+        public static RegistrationBuilder RegisterComponent<TInterface>(
+            this IContainerBuilder builder,
+            TInterface component)
+            => builder.RegisterInstance(component).As(typeof(MonoBehaviour), typeof(TInterface));
+
         public static RegistrationBuilder RegisterComponentInHierarchy<T>(
             this IContainerBuilder builder
-            ) where T : Component
+            ) where T : MonoBehaviour
         {
             var lifetimeScope = (LifetimeScope)builder.ApplicationOrigin;
             var scene = lifetimeScope.gameObject.scene;
@@ -22,14 +44,14 @@ namespace VContainer.Unity
                 throw new VContainerException(typeof(T), $"Component {typeof(T)} is not in this scene {scene.path}");
             }
 
-            return builder.RegisterInstance(component);
+            return builder.RegisterInstance(component).As(typeof(MonoBehaviour), typeof(T));
         }
 
         public static ComponentRegistrationBuilder RegisterComponentOnNewGameObject<T>(
             this IContainerBuilder builder,
             Lifetime lifetime,
             string newGameObjectName = null)
-            where T : Component
+            where T : MonoBehaviour
         {
             var registrationBuilder = new ComponentRegistrationBuilder(
                 newGameObjectName,
@@ -43,7 +65,7 @@ namespace VContainer.Unity
             this IContainerBuilder builder,
             T prefab,
             Lifetime lifetime)
-            where T : Component
+            where T : MonoBehaviour
         {
             var registrationBuilder = new ComponentRegistrationBuilder(
                 prefab,

--- a/VContainer/Assets/VContainer/Runtime/Unity/LifetimeScope.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/LifetimeScope.cs
@@ -160,6 +160,7 @@ namespace VContainer.Unity
             {
                 InstallTo(new ContainerBuilder { ApplicationOrigin = this });
             }
+
             DispatchPlayerLoopItems();
         }
 
@@ -237,6 +238,7 @@ namespace VContainer.Unity
             {
                 extraInstaller.Install(builder);
             }
+
             Container = builder.Build();
         }
 
@@ -353,6 +355,14 @@ namespace VContainer.Unity
                 PlayerLoopHelper.Dispatch(PlayerLoopTiming.PostLateUpdate, loopItem);
             }
             catch (VContainerException ex) when(ex.InvalidType == typeof(IEnumerable<IPostLateTickable>))
+            {
+            }
+
+            try
+            {
+                var _ = Container.Resolve<IEnumerable<MonoBehaviour>>();
+            }
+            catch (VContainerException ex) when(ex.InvalidType == typeof(IEnumerable<MonoBehaviour>))
             {
             }
         }

--- a/VContainer/Assets/VContainer/Tests/Unity/SampleEntryPoint.cs
+++ b/VContainer/Assets/VContainer/Tests/Unity/SampleEntryPoint.cs
@@ -1,0 +1,33 @@
+using VContainer.Unity;
+
+namespace VContainer.Tests.Unity
+{
+    public sealed class SampleEntryPoint :
+        IInitializable,
+        IPostInitializable,
+        IFixedTickable,
+        IPostFixedTickable,
+        ITickable,
+        IPostTickable,
+        ILateTickable,
+        IPostLateTickable
+    {
+        public bool InitializeCalled;
+        public bool PostInitializeCalled;
+        public int FixedTickCalls;
+        public int PostFixedTickCalls;
+        public int TickCalls;
+        public int PostTickCalls;
+        public int LateTickCalls;
+        public int PostLateTickCalls;
+
+        void IInitializable.Initialize() => InitializeCalled = true;
+        void IPostInitializable.PostInitialize() => PostInitializeCalled = true;
+        void IFixedTickable.FixedTick() => FixedTickCalls += 1;
+        void IPostFixedTickable.PostFixedTick() => PostFixedTickCalls += 1;
+        void ITickable.Tick() => TickCalls += 1;
+        void IPostTickable.PostTick() => PostTickCalls += 1;
+        void ILateTickable.LateTick() => LateTickCalls += 1;
+        void IPostLateTickable.PostLateTick() => PostLateTickCalls += 1;
+    }
+}

--- a/VContainer/Assets/VContainer/Tests/Unity/SampleEntryPoint.cs.meta
+++ b/VContainer/Assets/VContainer/Tests/Unity/SampleEntryPoint.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: d77d24d60bbb4a9bba51de1f7ae5116f
+timeCreated: 1593834944

--- a/VContainer/Assets/VContainer/Tests/Unity/SampleMonoBehaviour.cs
+++ b/VContainer/Assets/VContainer/Tests/Unity/SampleMonoBehaviour.cs
@@ -2,7 +2,27 @@ using UnityEngine;
 
 namespace VContainer.Tests.Unity
 {
-    public sealed class SampleMonoBehaviour : MonoBehaviour
+    public interface IComponent
     {
+    }
+
+    public class ServiceA
+    {
+    }
+
+    public sealed class SampleMonoBehaviour : MonoBehaviour, IComponent
+    {
+        public ServiceA ServiceA;
+        public bool StartCalled;
+        public int UpdateCalls;
+
+        void Start() => StartCalled = true;
+        void Update() => UpdateCalls += 1;
+
+        [Inject]
+        public void Construct(ServiceA serviceA)
+        {
+            ServiceA = serviceA;
+        }
     }
 }

--- a/VContainer/Assets/VContainer/Tests/Unity/UnityContainerBuilderTest.cs
+++ b/VContainer/Assets/VContainer/Tests/Unity/UnityContainerBuilderTest.cs
@@ -1,6 +1,7 @@
+using System.Collections;
 using NUnit.Framework;
 using UnityEngine;
-using UnityEngine.SceneManagement;
+using UnityEngine.TestTools;
 using VContainer.Unity;
 
 namespace VContainer.Tests.Unity
@@ -8,6 +9,49 @@ namespace VContainer.Tests.Unity
     [TestFixture]
     public class UnityContainerBuilderTest
     {
+        [Test]
+        public void RegisterEntryPoint()
+        {
+            var builder = new ContainerBuilder();
+            builder.RegisterEntryPoint<SampleEntryPoint>(Lifetime.Singleton);
+
+            var container = builder.Build();
+            Assert.That(container.Resolve<IInitializable>(), Is.InstanceOf<IInitializable>());
+            Assert.That(container.Resolve<IPostInitializable>(), Is.InstanceOf<IPostInitializable>());
+            Assert.That(container.Resolve<IFixedTickable>(), Is.InstanceOf<IFixedTickable>());
+            Assert.That(container.Resolve<IPostFixedTickable>(), Is.InstanceOf<IPostFixedTickable>());
+            Assert.That(container.Resolve<ITickable>(), Is.InstanceOf<ITickable>());
+            Assert.That(container.Resolve<IPostTickable>(), Is.InstanceOf<IPostTickable>());
+            Assert.That(container.Resolve<ILateTickable>(), Is.InstanceOf<ILateTickable>());
+            Assert.That(container.Resolve<IPostLateTickable>(), Is.InstanceOf<IPostLateTickable>());
+        }
+
+        [Test]
+        public void RegisterComponent()
+        {
+            var component = new GameObject("SampleBehaviour").AddComponent<SampleMonoBehaviour>();
+            {
+                var builder = new ContainerBuilder();
+                builder.Register<ServiceA>(Lifetime.Transient);
+                builder.RegisterComponent(component);
+
+                var container = builder.Build();
+
+                Assert.That(container.Resolve<SampleMonoBehaviour>(), Is.EqualTo(component));
+                Assert.That(container.Resolve<MonoBehaviour>(), Is.InstanceOf<MonoBehaviour>());
+            }
+            {
+                var builder = new ContainerBuilder();
+                builder.Register<ServiceA>(Lifetime.Transient);
+                builder.RegisterComponent<IComponent>(component);
+
+                var container = builder.Build();
+
+                Assert.That(container.Resolve<IComponent>(), Is.EqualTo(component));
+                Assert.That(container.Resolve<MonoBehaviour>(), Is.InstanceOf<MonoBehaviour>());
+            }
+        }
+
         [Test]
         public void RegisterComponentInHierarchy()
         {
@@ -22,12 +66,15 @@ namespace VContainer.Tests.Unity
             go3.AddComponent<SampleMonoBehaviour>();
 
             var builder = new ContainerBuilder { ApplicationOrigin = lifetimeScope };
+            builder.Register<ServiceA>(Lifetime.Transient);
             builder.RegisterComponentInHierarchy<SampleMonoBehaviour>();
 
             var container = builder.Build();
             var resolved = container.Resolve<SampleMonoBehaviour>();
             Assert.That(resolved, Is.InstanceOf<SampleMonoBehaviour>());
-            Assert.That(resolved.gameObject, Is.EqualTo(go3));
+            Assert.That(resolved.transform, Is.EqualTo(go3.transform));
+
+            Assert.That(container.Resolve<MonoBehaviour>(), Is.InstanceOf<MonoBehaviour>());
         }
 
         [Test]
@@ -36,12 +83,14 @@ namespace VContainer.Tests.Unity
             {
                 var go1 = new GameObject("Parent");
                 var builder = new ContainerBuilder();
+                builder.Register<ServiceA>(Lifetime.Transient);
                 builder.RegisterComponentOnNewGameObject<SampleMonoBehaviour>(Lifetime.Transient, "hoge")
                     .UnderTransform(go1.transform);
 
                 var container = builder.Build();
                 var resolved1 = container.Resolve<SampleMonoBehaviour>();
                 var resolved2 = container.Resolve<SampleMonoBehaviour>();
+
                 Assert.That(resolved1.gameObject.name, Is.EqualTo("hoge"));
                 Assert.That(resolved2.gameObject.name, Is.EqualTo("hoge"));
                 Assert.That(resolved1, Is.InstanceOf<SampleMonoBehaviour>());
@@ -49,10 +98,13 @@ namespace VContainer.Tests.Unity
                 Assert.That(resolved1.transform.parent, Is.EqualTo(go1.transform));
                 Assert.That(resolved2.transform.parent, Is.EqualTo(go1.transform));
                 Assert.That(resolved1, Is.Not.EqualTo(resolved2));
+
+                Assert.That(container.Resolve<MonoBehaviour>(), Is.InstanceOf<MonoBehaviour>());
             }
 
             {
                 var builder = new ContainerBuilder();
+                builder.Register<ServiceA>(Lifetime.Transient);
                 builder.RegisterComponentOnNewGameObject<SampleMonoBehaviour>(Lifetime.Scoped, "hoge");
 
                 var container = builder.Build();
@@ -66,8 +118,17 @@ namespace VContainer.Tests.Unity
                 Assert.That(resolved2.transform.parent, Is.Null);
                 Assert.That(resolved1, Is.EqualTo(resolved2));
             }
-        }
 
+
+            {
+                var builder = new ContainerBuilder();
+                builder.Register<ServiceA>(Lifetime.Transient);
+                builder.RegisterComponentOnNewGameObject<SampleMonoBehaviour>(Lifetime.Scoped, "hoge");
+
+                var container = builder.Build();
+                Assert.That(container.Resolve<MonoBehaviour>(), Is.InstanceOf<MonoBehaviour>());
+            }
+        }
 
         [Test]
         public void RegisterComponentInNewPrefab()
@@ -76,6 +137,7 @@ namespace VContainer.Tests.Unity
             {
                 var go1 = new GameObject("Parent");
                 var builder = new ContainerBuilder();
+                builder.Register<ServiceA>(Lifetime.Transient);
                 builder.RegisterComponentInNewPrefab(prefab, Lifetime.Transient)
                     .UnderTransform(go1.transform);
 
@@ -93,6 +155,7 @@ namespace VContainer.Tests.Unity
 
             {
                 var builder = new ContainerBuilder();
+                builder.Register<ServiceA>(Lifetime.Transient);
                 builder.RegisterComponentInNewPrefab(prefab, Lifetime.Scoped);
 
                 var container = builder.Build();
@@ -106,6 +169,36 @@ namespace VContainer.Tests.Unity
                 Assert.That(resolved2.transform.parent, Is.Null);
                 Assert.That(resolved1, Is.EqualTo(resolved2));
             }
+
+            {
+                var builder = new ContainerBuilder();
+                builder.Register<ServiceA>(Lifetime.Transient);
+                builder.RegisterComponentInNewPrefab(prefab, Lifetime.Scoped);
+
+                var container = builder.Build();
+                Assert.That(container.Resolve<MonoBehaviour>(), Is.InstanceOf<MonoBehaviour>());
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator DispatchMonoBehaviour()
+        {
+            var lifetimeScope = default(LifetimeScope);
+            var component = new GameObject("SampleBehaviour").AddComponent<SampleMonoBehaviour>();
+            using (LifetimeScope.Push(bulder =>
+            {
+                bulder.Register<ServiceA>(Lifetime.Transient);
+                bulder.RegisterComponent(component);
+            }))
+            {
+                lifetimeScope = new GameObject("LifetimeScope").AddComponent<LifetimeScope>();
+            }
+
+            yield return null;
+
+            Assert.That(component.ServiceA, Is.InstanceOf<ServiceA>());
+            Assert.That(component.StartCalled, Is.True);
+            Assert.That(component.UpdateCalls, Is.GreaterThanOrEqualTo(1));
         }
     }
 }

--- a/VContainer/VContainer.csproj
+++ b/VContainer/VContainer.csproj
@@ -274,9 +274,6 @@
  <Reference Include="UnityEngine.XRModule">
  <HintPath>/Applications/Unity/2019.4.1f1/Unity.app/Contents/Managed/UnityEngine/UnityEngine.XRModule.dll</HintPath>
  </Reference>
- <Reference Include="UnityEditor.VR">
- <HintPath>/Applications/Unity/2019.4.1f1/Unity.app/Contents/UnityExtensions/Unity/UnityVR/Editor/UnityEditor.VR.dll</HintPath>
- </Reference>
  <Reference Include="UnityEditor.Graphs">
  <HintPath>/Applications/Unity/2019.4.1f1/Unity.app/Contents/Managed/UnityEditor.Graphs.dll</HintPath>
  </Reference>


### PR DESCRIPTION
Add new two register methods

## `RegisterEntryPoint<T>`

To register entry point markers, (e.g: `IInitializable`, `ITickable`, etc) we used this until now:

```csharp
builder.Register<Foo>(..).As<ITickable>();
// Or
builder.Register<Foo>(...).AsImplementedInterfaces();
```

- I think this is explicit, but a bit unclear about side effects
- This is a bit frequently, so I think it is better to have a shorter hand.

I will add following:

```csharp
builder.RegisterEntryPoint<Foo>(..);
```

## `RegisterComponent<T>`

In the following cases, I noticed that Inject doesn't work even though I have an instance of MonoBehaviour.

```csharp
public MyMonoBehaviour : MonoBehaviour
{
    [Inject]
    public void Construct(ServiceA a) { /* ... */ }
}

public class MyInstaller : MonoInstaller
{
    [SerializeField]
    MyMonoBehaviour component;

    public void Install(IContainerBuilder builder)
    {
        builder.RegisterInstance(component);

        // Nothing to other.
    }
}
```

In this case, MyMonoBehaviour registered, but nothing to resolve, then nothing inject.
To fix this, Inject now works when Registering MonoBehaviour.

However, container needs to know that the registered obj is MonoBehaviour. Therefore, I added RegisterComponent instead of RegisterInstance.

```csharp
    [SerializeField]
    MyMonoBehaviour component;

    // ...

    builder.RegisterComponent(component);
```
