### PR TITLE
Move RootLieftimeScope settings to VContainerSettings

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,14 @@ Following is a deep profiler Unity result sample.
 
 ![](docs/screenshot_profiler_zenject.png)
 
-## Breaking Changes from v0.0.x
+## Breaking Changes
 
-- From 0.0.x, API has changed.
-  - [Obsolete MonoInstaller/ScriptableObjectInstaller and instead inherit LifetimeScope](https://github.com/hadashiA/VContainer/pull/15)
+- From 0.0.x
+  - [Remove MonoInstaller/ScriptableObjectInstaller and instead inherit LifetimeScope](https://github.com/hadashiA/VContainer/pull/15)
   - If you are using an earlier version, please check [Getting Started](#getting-started) again.
+- From 0.2.x
+  - [Use `VContainerSettings` instead of automatically loading Resources](https://github.com/hadashiA/VContainer/pull/25
+  - If you were using "ProjectLifetimeScope" in Resources, please check [How to create project root LifetimeScope](#how-to-create-project-root-lifetimescope)
 
 ## Index
 
@@ -925,11 +928,17 @@ using (LifetimeScope.Push(fooInstaller)
 }
 ```
 
-### Project Root
+### How to create project root LifetimeScope
 
-You can create a parent for all LifetimeScopes in your scene.
+You can specify a root LifetimeScope that will be the parent of all LifetimeScopes.  
 
-To do so, create a `LifetimeScope` subclass prefab in a folder named `Resources` in Assets and name it "ProjectLifetimeScope".
+- 1. Create your root LifetimeScope prefab
+- 2. Create `VContainerSettings`
+    - Choose `Assets -> Create -> VContaienr -> VContainer Settings`
+    - Note:
+        - If you create VContainerSettings from this menu, it will be automatically registered in preload assets.
+- 3. From your VContainerSettings inspector, set your prefab to the **Root Lifetime Scope** section.
+
 
 ## Dispatching Unity Lifecycle
 

--- a/VContainer/Assets/VContainer/Editor/CodeGen.meta
+++ b/VContainer/Assets/VContainer/Editor/CodeGen.meta
@@ -1,3 +1,0 @@
-﻿fileFormatVersion: 2
-guid: b1fbc4ba07964adc8ecfa036ac830d42
-timeCreated: 1594288504

--- a/VContainer/Assets/VContainer/Editor/CodeGen/VContainerILPostProcessor.cs
+++ b/VContainer/Assets/VContainer/Editor/CodeGen/VContainerILPostProcessor.cs
@@ -4,6 +4,7 @@ using Unity.CompilationPipeline.Common.Diagnostics;
 using Unity.CompilationPipeline.Common.ILPostProcessing;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
+using VContainer.Unity;
 
 namespace VContainer.Editor.CodeGen
 {

--- a/VContainer/Assets/VContainer/Editor/VContainerSettings.cs.meta
+++ b/VContainer/Assets/VContainer/Editor/VContainerSettings.cs.meta
@@ -1,3 +1,0 @@
-﻿fileFormatVersion: 2
-guid: cf05ae6ecc0242b681226a809b30c3ae
-timeCreated: 1595484573

--- a/VContainer/Assets/VContainer/Editor/VContainerSettingsEditor.cs
+++ b/VContainer/Assets/VContainer/Editor/VContainerSettingsEditor.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 using UnityEditor;
 using UnityEditorInternal;
 using UnityEngine;
+using VContainer.Unity;
 
 namespace VContainer.Editor
 {
@@ -26,6 +27,9 @@ namespace VContainer.Editor
 
             using (var scope = new EditorGUI.ChangeCheckScope())
             {
+                var rootLifetimeScopeProp = serializedObject.FindProperty("RootLifetimeScope");
+                EditorGUILayout.PropertyField(rootLifetimeScopeProp);
+
                 expandCodeGen = EditorGUILayout.Foldout(expandCodeGen, "Prepare Code Generation", true);
                 if (expandCodeGen)
                 {

--- a/VContainer/Assets/VContainer/Editor/VContainerSettingsEditor.cs.meta
+++ b/VContainer/Assets/VContainer/Editor/VContainerSettingsEditor.cs.meta
@@ -1,3 +1,11 @@
-﻿fileFormatVersion: 2
-guid: 086d1f02a80d4633aaced41d23477067
-timeCreated: 1595492413
+fileFormatVersion: 2
+guid: a71622b13e9fb4ff28937885bb67dcc4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VContainer/Assets/VContainer/Runtime/Unity/VContainerSettings.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/VContainerSettings.cs
@@ -1,8 +1,9 @@
 using System;
 using System.Linq;
 using UnityEngine;
+using VContainer.Unity;
 
-namespace VContainer.Editor
+namespace VContainer.Unity
 {
     [Serializable]
     public sealed class CodeGenSettings
@@ -15,10 +16,12 @@ namespace VContainer.Editor
     public sealed class VContainerSettings : ScriptableObject
     {
         [SerializeField]
+        public LifetimeScope RootLifetimeScope;
+
+        [SerializeField]
         public CodeGenSettings CodeGen;
 
         public static VContainerSettings Instance { get; private set; }
-
 
 #if UNITY_EDITOR
         [UnityEditor.MenuItem("Assets/Create/VContainer/VContainer Settings")]
@@ -56,6 +59,8 @@ namespace VContainer.Editor
 
         void OnEnable()
         {
+            if (RootLifetimeScope != null)
+                RootLifetimeScope.IsRoot = true;
             Instance = this;
         }
     }

--- a/VContainer/Assets/VContainer/Runtime/Unity/VContainerSettings.cs.meta
+++ b/VContainer/Assets/VContainer/Runtime/Unity/VContainerSettings.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 9cf4d8df1d704d5689f3c69bd70d1cb9
+timeCreated: 1595759041


### PR DESCRIPTION
### How to create project root LifetimeScope
You can create a parent for all LifetimeScopes in your scene.
You can specify a root LifetimeScope that will be the parent of all LifetimeScopes.  
- 1. Create your root LifetimeScope prefab
- 2. Create `VContainerSettings`
    - Choose `Assets -> Create -> VContaienr -> VContainer Settings`
    - Note:
        - If you create VContainerSettings from this menu, it will be automatically registered in preload assets.
- 3. From your VContainerSettings inspector, set your prefab to the **Root Lifetime Scope** section.
