### PR TITLE
Fix an error where singleton registered in a child

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/Container.cs
+++ b/VContainer/Assets/VContainer/Runtime/Container.cs
@@ -63,7 +63,11 @@ namespace VContainer
                     return registration.SpawnInstance(this);
 
                 case Lifetime.Singleton:
-                    return Root.Resolve(registration);
+                    if (registry.Exists(registration))
+                    {
+                        return sharedInstances.GetOrAdd(registration, createInstance).Value;
+                    }
+                    return Parent.Resolve(registration);
 
                 case Lifetime.Scoped:
                     var lazy = sharedInstances.GetOrAdd(registration, createInstance);

--- a/VContainer/Assets/VContainer/Runtime/Internal/FixedTypeKeyHashTableRegistry.cs
+++ b/VContainer/Assets/VContainer/Runtime/Internal/FixedTypeKeyHashTableRegistry.cs
@@ -104,5 +104,21 @@ namespace VContainer.Internal
             }
             return false;
         }
+
+        public bool Exists(IRegistration registration)
+        {
+            if (registration.InterfaceTypes?.Count > 0)
+            {
+                foreach (var type in registration.InterfaceTypes)
+                {
+                    if (hashTable.TryGet(type, out _))
+                    {
+                        return true;
+                    }
+                }
+                return false;
+            }
+            return hashTable.TryGet(registration.ImplementationType, out _);
+        }
     }
 }

--- a/VContainer/Assets/VContainer/Runtime/Internal/IRegistry.cs
+++ b/VContainer/Assets/VContainer/Runtime/Internal/IRegistry.cs
@@ -6,5 +6,6 @@ namespace VContainer.Internal
     {
         // void Add(Registration registration);
         bool TryGet(Type interfaceType, out IRegistration registration);
+        bool Exists(IRegistration registration);
     }
 }

--- a/VContainer/Assets/VContainer/Runtime/Unity/LifetimeScope.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/LifetimeScope.cs
@@ -10,7 +10,6 @@ using Unity.Entities;
 
 namespace VContainer.Unity
 {
-
     public class LifetimeScope : MonoBehaviour
     {
         public readonly struct ParentOverrideScope : IDisposable


### PR DESCRIPTION
It was found that in some cases, Lifetime.Singleton could not be resolved when registering `Lifetime.Singleton` in its child scope.

Expected behaviour
- A Singleton registered in a child scope can be resolved in a scope below that scope