### PR TITLE
Fix a problem with duplicate instances when resolving a Singleton  from a child scope

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/Container.cs
+++ b/VContainer/Assets/VContainer/Runtime/Container.cs
@@ -67,7 +67,7 @@ namespace VContainer
                     {
                         return sharedInstances.GetOrAdd(registration, createInstance).Value;
                     }
-                    return Parent.Resolve(registration);
+                    return (Parent.Parent is null ? Parent.Root : Parent).Resolve(registration);
 
                 case Lifetime.Scoped:
                     var lazy = sharedInstances.GetOrAdd(registration, createInstance);

--- a/VContainer/Assets/VContainer/Tests/ScopedContainerTest.cs
+++ b/VContainer/Assets/VContainer/Tests/ScopedContainerTest.cs
@@ -120,10 +120,12 @@ namespace VContainer.Tests
             {
                 var parentSingleton = grandChildContainer.Resolve<NoDependencyServiceA>();
                 Assert.That(parentSingleton, Is.InstanceOf<NoDependencyServiceA>());
+                Assert.That(parentSingleton, Is.EqualTo(parentContainer.Resolve<NoDependencyServiceA>()));
 
                 var childSingleton = grandChildContainer.Resolve<ServiceA>();
                 Assert.That(childSingleton, Is.InstanceOf<ServiceA>());
                 Assert.That(childSingleton.Service2, Is.InstanceOf<I2>());
+                Assert.That(childSingleton, Is.EqualTo(childContainer.Resolve<ServiceA>()));
 
                 var grandChildSingleton = grandChildContainer.Resolve<ServiceB>();
                 Assert.That(grandChildSingleton, Is.InstanceOf<ServiceB>());


### PR DESCRIPTION
Singleton in the root container had to be taken out of the Root container.