### PR TITLE
Fix a bug that inject constructor targets .cctor

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/Internal/TypeAnalyzer.cs
+++ b/VContainer/Assets/VContainer/Runtime/Internal/TypeAnalyzer.cs
@@ -99,8 +99,7 @@ namespace VContainer.Internal
             // Constructor, single [Inject] constructor -> single most parameters constuctor
             var injectConstructorCount = 0;
             var maxParameters = -1;
-            foreach (var constructorInfo in typeInfo.DeclaredConstructors)
-            {
+            foreach (var constructorInfo in typeInfo.GetConstructors(BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)) {
                 if (constructorInfo.IsDefined(typeof(InjectAttribute), true))
                 {
                     if (++injectConstructorCount > 1)

--- a/VContainer/Assets/VContainer/Tests/TypeAnalyzerTest.cs
+++ b/VContainer/Assets/VContainer/Tests/TypeAnalyzerTest.cs
@@ -22,6 +22,16 @@ namespace VContainer.Tests
             }
         }
 
+        class HasStaticConstructor
+        {
+            static int Foo = 400;
+
+            [Inject]
+            public HasStaticConstructor()
+            {
+            }
+        }
+
         class HasInjectConstructor
         {
             [Inject]
@@ -56,7 +66,11 @@ namespace VContainer.Tests
             }
             {
                 var injectTypeInfo = TypeAnalyzer.Analyze(typeof(HasInjectConstructor));
-                // Assert.That(injectTypeInfo.InjectConstructor.ConstructorInfo.GetCustomAttribute<InjectAttribute>(), Is.Not.Null);
+                Assert.That(injectTypeInfo.InjectConstructor.ConstructorInfo.GetCustomAttribute<InjectAttribute>(), Is.Not.Null);
+            }
+            {
+                var injectTypeInfo = TypeAnalyzer.Analyze(typeof(HasStaticConstructor));
+                Assert.That(injectTypeInfo.InjectConstructor.ConstructorInfo.IsStatic, Is.False);
             }
         }
     }


### PR DESCRIPTION
Fix a bug where classes with static constructors couldn't detect the inject constructor correctly.

@monry gives me a bug report. Thanks!
https://github.com/monry/BugReports_VContainer_static_fields