### PR TITLE
Add LifetimeScope.Create

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/Unity/LifetimeScope.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/LifetimeScope.cs
@@ -36,7 +36,18 @@ namespace VContainer.Unity
         static ExtraInstaller extraInstaller;
         static readonly object SyncRoot = new object();
 
-        public static ParentOverrideScope PushParent(LifetimeScope parent) => new ParentOverrideScope(parent);
+        public static LifetimeScope Create(Action<IContainerBuilder> installation)
+        {
+            using (Push(installation)) return Create();
+        }
+
+        public static LifetimeScope Create(IInstaller installer = null)
+        {
+            using (Push(installer)) return Create();
+        }
+
+        public static ParentOverrideScope PushParent(LifetimeScope parent)
+            => new ParentOverrideScope(parent);
 
         public static ExtraInstallationScope Push(Action<IContainerBuilder> installing)
             => new ExtraInstallationScope(new ActionInstaller(installing));
@@ -44,11 +55,17 @@ namespace VContainer.Unity
         public static ExtraInstallationScope Push(IInstaller installer)
             => new ExtraInstallationScope(installer);
 
-        public static LifetimeScope Find<T>(Scene scene) where T : LifetimeScope
-            => Find(typeof(T), scene);
+        public static LifetimeScope Find<T>(Scene scene) where T : LifetimeScope => Find(typeof(T), scene);
+        public static LifetimeScope Find<T>() where T : LifetimeScope => Find(typeof(T));
 
-        public static LifetimeScope Find<T>() where T : LifetimeScope
-            => Find(typeof(T));
+        static LifetimeScope Create()
+        {
+            var gameObject = new GameObject("LifeTimeScope");
+            gameObject.SetActive(false);
+            var newScope = gameObject.AddComponent<LifetimeScope>();
+            gameObject.SetActive(true);
+            return newScope;
+        }
 
         static LifetimeScope Find(Type type, Scene scene)
         {

--- a/VContainer/Assets/VContainer/Tests/Unity/LifetimeScopeTest.cs
+++ b/VContainer/Assets/VContainer/Tests/Unity/LifetimeScopeTest.cs
@@ -26,6 +26,29 @@ namespace VContainer.Tests.Unity
         }
 
         [UnityTest]
+        public IEnumerator Create()
+        {
+            var lifetimeScope = LifetimeScope.Create(builder =>
+            {
+                builder.RegisterEntryPoint<SampleEntryPoint>(Lifetime.Scoped).AsSelf();
+                builder.Register<DisposableServiceA>(Lifetime.Scoped);
+            });
+
+            yield return null;
+            yield return null;
+
+            var entryPoint = lifetimeScope.Container.Resolve<SampleEntryPoint>();
+            Assert.That(entryPoint, Is.InstanceOf<SampleEntryPoint>());
+            Assert.That(entryPoint.InitializeCalled, Is.True);
+            Assert.That(entryPoint.TickCalls, Is.EqualTo(2));
+
+            var disposable = lifetimeScope.Container.Resolve<DisposableServiceA>();
+            lifetimeScope.Dispose();
+            yield return null;
+            Assert.That(disposable.Disposed, Is.True);
+        }
+
+        [UnityTest]
         public IEnumerator CreateChild()
         {
             LifetimeScope parentLifetimeScope;


### PR DESCRIPTION
Allow to instantly generate a LifetimeScope.

```csharp
LifetimeScope.Create(builder =>
{
    builder.Register<Foo>(Lifetime.Scoped);
});
```

Without inheritance:

```csharp
class FooBehaviour : MonoBehaviour
{
    [SerializedField]
    SomeAsset someAsset;

    void Start()
    {
        LIfetimeScope.Create(builder =>
        {
            builder.Register<SomeEntryPoint>(LifetimeScoped);
            builder.RegisterInstance(someAsset);
        });
    }
}
```