### PR TITLE
Fix out of range error for CappedArrayPool<>

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/Internal/CappedArrayPool.cs
+++ b/VContainer/Assets/VContainer/Runtime/Internal/CappedArrayPool.cs
@@ -4,7 +4,7 @@ namespace VContainer.Internal
 {
     sealed class CappedArrayPool<T>
     {
-        const int InitialBucketSize = 4;
+        internal const int InitialBucketSize = 4;
 
         public static readonly T[] EmptyArray = new T[0];
         public static readonly CappedArrayPool<T> Shared8Limit = new CappedArrayPool<T>(8);
@@ -13,7 +13,7 @@ namespace VContainer.Internal
         readonly object syncRoot = new object();
         readonly int[] tails;
 
-        CappedArrayPool(int maxLength)
+        internal CappedArrayPool(int maxLength)
         {
             buckets = new T[maxLength][][];
             tails = new int[maxLength];
@@ -46,6 +46,7 @@ namespace VContainer.Internal
                 if (tail >= bucket.Length)
                 {
                     Array.Resize(ref bucket, bucket.Length * 2);
+                    buckets[i] = bucket;
                 }
 
                 var result = bucket[tail] ?? new T[length];

--- a/VContainer/Assets/VContainer/Tests/CappedArrayPoolTest.cs
+++ b/VContainer/Assets/VContainer/Tests/CappedArrayPoolTest.cs
@@ -1,0 +1,22 @@
+using NUnit.Framework;
+using VContainer.Internal;
+
+namespace VContainer.Tests
+{
+    [TestFixture]
+    public class CappedArrayPoolTest
+    {
+        [Test]
+        public void RentWithExpandBucket()
+        {
+            var cappedArrayPool = new CappedArrayPool<object>(8);
+            Assert.DoesNotThrow(() =>
+            {
+                for (var i = 1; i < CappedArrayPool<object>.InitialBucketSize * 2; i++)
+                {
+                    cappedArrayPool.Rent(1);
+                }
+            });
+        }
+    }
+}

--- a/VContainer/Assets/VContainer/Tests/CappedArrayPoolTest.cs.meta
+++ b/VContainer/Assets/VContainer/Tests/CappedArrayPoolTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6cc78b0399f4a432eb75c4dff1a7af01
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Fix a bug that caused an IndexOutOfRangeException when expanding the CappedArrayPool <T> buffer.
There was a fatal problem that the new buffer was not saved properly.

Thanks for reporting this issue #60 