### PR TITLE
Rename LifetimeScope.Push to LifetimeScope.Enqueue

### DIFF
--- a/README.md
+++ b/README.md
@@ -960,7 +960,7 @@ class SceneLoader
     IEnumerator LoadSceneAsync()
     {
         // LifetimeScope generated in this block will be parented by `this.lifetimeScope`
-        using (LifetimeScope.PushParent(parent))
+        using (LifetimeScope.EnqueueParent(parent))
         {
             // If this scene has a LifetimeScope, its parent will be `parent`.
             var loading = SceneManager.LoadSceneAsync("...", LoadSceneMode.Additive);
@@ -974,7 +974,7 @@ class SceneLoader
     // UniTask example
     async UniTask LoadSceneAsync()
     {
-        using (LifetimeScope.PushParent(parent))
+        using (LifetimeScope.EnqueueParent(parent))
         {
             await SceneManager.LoadSceneAsync("...", LoadSceneMode.Additive);
         }        
@@ -998,7 +998,7 @@ In that case you could use:
 
 ```csharp
 // LifetimeScopes generated during this block will be additionally Registered.
-using (LifetimeScope.Push(builder =>
+using (LifetimeScope.Enqueue(builder =>
 {
     // Register for the next scene not yet loaded
     builder.RegisterInstance(extraInstance);
@@ -1018,16 +1018,16 @@ class FooInstaller : IInstaller
     }
 }
 
-using (LifetimeScope.Push(fooInstaller)
+using (LifetimeScope.Enqueue(fooInstaller)
 {
     // ... loading scene
 }
 ```
 
 ```csharp
-// PushParent() and Push() can be used together.
-using (LifetimeScope.PushParent(parent))
-using (LifetimeScope.Push(builder => ...)
+// EnqueueParent() and Enqueue() can be used together.
+using (LifetimeScope.EnqueueParent(parent))
+using (LifetimeScope.Enqueue(builder => ...)
 {
     // ... loading scene
 }

--- a/VContainer/Assets/VContainer/Runtime/Unity/LifetimeScope.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/LifetimeScope.cs
@@ -52,14 +52,23 @@ namespace VContainer.Unity
         public static LifetimeScope Create(Action<IContainerBuilder> installation)
             => Create(new ActionInstaller(installation));
 
-        public static ParentOverrideScope PushParent(LifetimeScope parent)
+        public static ParentOverrideScope EnqueueParent(LifetimeScope parent)
             => new ParentOverrideScope(parent);
 
-        public static ExtraInstallationScope Push(Action<IContainerBuilder> installing)
+        public static ExtraInstallationScope Enqueue(Action<IContainerBuilder> installing)
             => new ExtraInstallationScope(new ActionInstaller(installing));
 
-        public static ExtraInstallationScope Push(IInstaller installer)
+        public static ExtraInstallationScope Enqueue(IInstaller installer)
             => new ExtraInstallationScope(installer);
+
+        [Obsolete("LifetimeScope.PushParent is obsolete. Use LifetimeScope.EnqueueParent instead.", false)]
+        public static ParentOverrideScope PushParent(LifetimeScope parent) => new ParentOverrideScope(parent);
+
+        [Obsolete("LifetimeScope.Push is obsolete. Use LifetimeScope.Enqueue instead.", false)]
+        public static ExtraInstallationScope Push(Action<IContainerBuilder> installing) => Enqueue(installing);
+
+        [Obsolete("LifetimeScope.Push is obsolete. Use LifetimeScope.Enqueue instead.", false)]
+        public static ExtraInstallationScope Push(IInstaller installer) => Enqueue(installer);
 
         public static LifetimeScope Find<T>(Scene scene) where T : LifetimeScope => Find(typeof(T), scene);
         public static LifetimeScope Find<T>() where T : LifetimeScope => Find(typeof(T));

--- a/VContainer/Assets/VContainer/Tests/Unity/LifetimeScopeTest.cs
+++ b/VContainer/Assets/VContainer/Tests/Unity/LifetimeScopeTest.cs
@@ -11,11 +11,11 @@ namespace VContainer.Tests.Unity
     public class LifetimeScopeTest
     {
         [Test]
-        public void PushParent()
+        public void EnqueueParent()
         {
             var parent = new GameObject("LifetimeScope").AddComponent<LifetimeScope>();
 
-            using (LifetimeScope.PushParent(parent))
+            using (LifetimeScope.EnqueueParent(parent))
             {
                 var child = new GameObject("LifetimeScope Child 1").AddComponent<LifetimeScope>();
                 Assert.That(child.Parent, Is.EqualTo(parent));
@@ -53,16 +53,10 @@ namespace VContainer.Tests.Unity
         [UnityTest]
         public IEnumerator CreateChild()
         {
-            LifetimeScope parentLifetimeScope;
-
-            using (LifetimeScope.Push(builder =>
+            var parentLifetimeScope = LifetimeScope.Create(builder =>
             {
                 builder.RegisterEntryPoint<SampleEntryPoint>(Lifetime.Scoped).AsSelf();
-            }))
-            {
-                parentLifetimeScope = new GameObject("SampleLifetimeScope")
-                    .AddComponent<SampleLifetimeScope>();
-            }
+            });
 
             yield return null;
             yield return null;
@@ -105,15 +99,10 @@ namespace VContainer.Tests.Unity
         [Test]
         public void CreateScopeWithSingleton()
         {
-            LifetimeScope parentLifetimeScope;
-
-            using (LifetimeScope.Push(builder =>
+            var parentLifetimeScope = LifetimeScope.Create(builder =>
             {
                 builder.RegisterEntryPoint<SampleEntryPoint>(Lifetime.Singleton).AsSelf();
-            }))
-            {
-                parentLifetimeScope = new GameObject("LifetimeScope").AddComponent<LifetimeScope>();
-            }
+            });
 
             var parentEntryPoint = parentLifetimeScope.Container.Resolve<SampleEntryPoint>();
             Assert.That(parentEntryPoint, Is.InstanceOf<SampleEntryPoint>());


### PR DESCRIPTION
I wondered if the queue analogy would be easier to guess that the one registered earlier would be kept waiting and executed later.