### PR TITLE
Reduce allocation for buffer of GameObject

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/Unity/ContainerBuilderUnityExtensions.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/ContainerBuilderUnityExtensions.cs
@@ -1,6 +1,6 @@
 using System;
 using UnityEngine;
-
+using VContainer.Internal;
 #if VCONTAINER_ECS_INTEGRATION
 using Unity.Entities;
 #endif
@@ -94,9 +94,12 @@ namespace VContainer.Unity
             var lifetimeScope = (LifetimeScope)builder.ApplicationOrigin;
             var scene = lifetimeScope.gameObject.scene;
             var component = default(T);
-            foreach (var x in scene.GetRootGameObjects())
+
+            var gameObjectBuffer = UnityEngineObjectListBuffer<GameObject>.Get();
+            scene.GetRootGameObjects(gameObjectBuffer);
+            foreach (var gameObject in gameObjectBuffer)
             {
-                component = x.GetComponentInChildren<T>(true);
+                component = gameObject.GetComponentInChildren<T>(true);
                 if (component != null) break;
             }
 

--- a/VContainer/Assets/VContainer/Runtime/Unity/LifetimeScope.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/LifetimeScope.cs
@@ -33,8 +33,6 @@ namespace VContainer.Unity
         [SerializeField]
         protected List<GameObject> autoInjectGameObjects;
 
-        static readonly List<GameObject> GameObjectBuffer = new List<GameObject>(32);
-
         static LifetimeScope overrideParent;
         static ExtraInstaller extraInstaller;
         static readonly object SyncRoot = new object();
@@ -78,10 +76,11 @@ namespace VContainer.Unity
 
         static LifetimeScope Find(Type type, Scene scene)
         {
-            scene.GetRootGameObjects(GameObjectBuffer);
-            foreach (var root in GameObjectBuffer)
+            var buffer = ListBuffer<GameObject>.Get();
+            scene.GetRootGameObjects(buffer);
+            foreach (var gameObject in buffer)
             {
-                var found = root.GetComponentInChildren(type) as LifetimeScope;
+                var found = gameObject.GetComponentInChildren(type) as LifetimeScope;
                 if (found != null)
                     return found;
             }

--- a/VContainer/Assets/VContainer/Runtime/Unity/ObjectResolverUnityExtensions.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/ObjectResolverUnityExtensions.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using VContainer.Internal;
 
 namespace VContainer.Unity
 {
@@ -6,14 +7,17 @@ namespace VContainer.Unity
     {
         public static void InjectGameObject(this IObjectResolver resolver, GameObject gameObject)
         {
+            var buffer = UnityEngineObjectListBuffer<MonoBehaviour>.Get();
+
             void InjectGameObjectRecursive(GameObject current)
             {
                 if (current == null) return;
 
-                var monoBehaviours = current.GetComponents<MonoBehaviour>();
-                foreach (var x in monoBehaviours)
+                buffer.Clear();
+                current.GetComponents(buffer);
+                foreach (var monoBehaviour in buffer)
                 {
-                    resolver.Inject(x);
+                    resolver.Inject(monoBehaviour);
                 }
 
                 var transform = current.transform;

--- a/VContainer/Assets/VContainer/Runtime/Unity/UnityEngineObjectListBuffer.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/UnityEngineObjectListBuffer.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+
+namespace VContainer.Internal
+{
+    static class UnityEngineObjectListBuffer<T> where T : UnityEngine.Object
+    {
+        const int DefaultCapacity = 32;
+
+        [ThreadStatic]
+        static List<T> Instance = new List<T>(DefaultCapacity);
+
+        public static List<T> Get()
+        {
+            if (Instance == null)
+                Instance = new List<T>(DefaultCapacity);
+            Instance.Clear();
+            return Instance;
+        }
+    }
+}

--- a/VContainer/Assets/VContainer/Runtime/Unity/UnityEngineObjectListBuffer.cs.meta
+++ b/VContainer/Assets/VContainer/Runtime/Unity/UnityEngineObjectListBuffer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: da1a74df3eab442e81879a0b2e6fac0e
+timeCreated: 1606668004

--- a/VContainer/VContainer.csproj
+++ b/VContainer/VContainer.csproj
@@ -85,6 +85,7 @@
      <Compile Include="Assets\VContainer\Runtime\Unity\ExtraInstaller.cs" />
      <Compile Include="Assets\VContainer\Runtime\Unity\ContainerBuilderUnityExtensions.cs" />
      <Compile Include="Assets\VContainer\Runtime\Unity\IInstaller.cs" />
+     <Compile Include="Assets\VContainer\Runtime\Unity\UnityEngineObjectListBuffer.cs" />
      <Compile Include="Assets\VContainer\Runtime\Unity\ObjectResolverUnityExtensions.cs" />
      <Compile Include="Assets\VContainer\Runtime\Unity\LifetimeScope.cs" />
      <Compile Include="Assets\VContainer\Runtime\Unity\ParentReference.cs" />


### PR DESCRIPTION
GetComponents / GetRootGameObjects can take a List<> as an argument, which can reduce the allocation of the resulting collection.

I decided to reduce allocation by keeping a static List<> dedicated for this purpose.