### PR TITLE
SerializeReference属性はUnityEngine.Object派生のフィールドを現状サポートしていません

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/Unity/VContainerSettings.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/VContainerSettings.cs
@@ -15,11 +15,7 @@ namespace VContainer.Unity
 
     public sealed class VContainerSettings : ScriptableObject
     {
-#if UNITY_2019_3_OR_NEWER
-        [SerializeReference]
-#else
         [SerializeField]
-#endif
         public LifetimeScope RootLifetimeScope;
 
         [SerializeField]


### PR DESCRIPTION
https://docs.unity3d.com/ScriptReference/SerializeReference.html

> The field type must not be of a type that specializes UnityEngine.Object.

`UnityEngine.Object` 派生のフィールドでも `SerializeField` のような挙動をしますが、これは仕様的に意図していない（未定義の）挙動であると考えられるため、 `LifetimeScope` をコンポーネント（ `MonoBehaviour` 派生クラス）でなくすか今回の対応のように `SerializeField` だけを使うのが適切ではないかと思いました。