### PR TITLE
ParentReferenceが毎フレームシリアライズされることによるエディタパフォーマンスの低下を解決

### DIFF
--- a/VContainer/Assets/VContainer/Editor/ParentReferencePropertyDrawer.cs
+++ b/VContainer/Assets/VContainer/Editor/ParentReferencePropertyDrawer.cs
@@ -49,8 +49,14 @@ namespace VContainer.Editor
                 if (index < 0) index = 0;
 
                 EditorGUI.LabelField(labelRect, "Parent");
-                index = EditorGUI.Popup(popupRect, index, names);
-                typeNameProp.stringValue = names[index];
+                using (var check = new EditorGUI.ChangeCheckScope())
+                {
+                    index = EditorGUI.Popup(popupRect, index, names);
+                    if (check.changed)
+                    {
+                        typeNameProp.stringValue = names[index];
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
`LifetimeScope` 派生クラスをインスペクタ上に表示していると定期的にスパイクが発生していたので調査したところ、`ParentReferencePropertyDrawer.OnGUI` で毎フレーム `LifetimeScope.ParentReference.OnBeforeSerialize|OnAfterDeserialize` が実行されているのが原因でした。

`ChangeCheckScope` によってUIに変更があったとき（ポップアップから要素が選択されたとき）だけシリアライズするように変更し、最低限のコストを消費するだけでよくなるようにしました。