### PR TITLE
Control the find scope of RegisterComponentInHierarchy.

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/Interfaces.meta
+++ b/VContainer/Assets/VContainer/Runtime/Interfaces.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1eb05967f0cc40c59ebf679dcc359905
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VContainer/Assets/VContainer/Runtime/Interfaces.meta
+++ b/VContainer/Assets/VContainer/Runtime/Interfaces.meta
@@ -1,3 +1,0 @@
-﻿fileFormatVersion: 2
-guid: 1eb05967f0cc40c59ebf679dcc359905
-timeCreated: 1612009399

--- a/VContainer/Assets/VContainer/Runtime/Unity/ComponentRegistration.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/ComponentRegistration.cs
@@ -1,25 +1,32 @@
 using System;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 namespace VContainer.Unity
 {
-    public sealed class ComponentDestination
+    sealed class ComponentDestination
     {
+        public readonly bool Find;
         public readonly Component Prefab;
         public readonly string NewGameObjectName;
+        public Scene Scene;
 
         readonly Transform parent;
         readonly Func<Transform> parentFinder;
 
         public ComponentDestination(
-            Component prefab,
+            bool find,
+            Scene scene,
             Transform parent,
             Func<Transform> parentFinder,
+            Component prefab,
             string newGameObjectName = null)
         {
+            Find = find;
             Prefab = prefab;
             NewGameObjectName = newGameObjectName;
+            Scene = scene;
             this.parent = parent;
             this.parentFinder = parentFinder;
         }
@@ -27,7 +34,7 @@ namespace VContainer.Unity
         public Transform GetParent() => parent != null ? parent : parentFinder?.Invoke();
     }
 
-    public sealed class ComponentRegistration : IRegistration
+    sealed class ComponentRegistration : IRegistration
     {
         public Type ImplementationType { get; }
         public Lifetime Lifetime { get; }
@@ -55,29 +62,83 @@ namespace VContainer.Unity
 
         public object SpawnInstance(IObjectResolver resolver)
         {
-            Component component;
-            var parent = destination.GetParent();
+            if (destination.Find)
+            {
+                return FindComponent(resolver);
+            }
             if (destination.Prefab != null)
             {
-                if (destination.Prefab.gameObject.activeSelf)
+                return InstantiatePrefab(resolver);
+            }
+            return InstantiateNewGameObject(resolver);
+        }
+
+        Component FindComponent(IObjectResolver resolver)
+        {
+            Component component = null;
+            var parent = destination.GetParent();
+            if (parent != null)
+            {
+                component = parent.GetComponentInChildren(ImplementationType);
+                if (component == null)
                 {
-                    destination.Prefab.gameObject.SetActive(false);
+                    throw new VContainerException(ImplementationType, $"Component {ImplementationType} is not in the parent {parent.name}");
                 }
-                component = UnityEngine.Object.Instantiate(destination.Prefab, parent);
+            }
+            else if (destination.Scene.IsValid())
+            {
+                var gameObjectBuffer = UnityEngineObjectListBuffer<GameObject>.Get();
+                destination.Scene.GetRootGameObjects(gameObjectBuffer);
+                foreach (var gameObject in gameObjectBuffer)
+                {
+                    component = gameObject.GetComponentInChildren(ImplementationType, true);
+                    if (component != null) break;
+                }
+                if (component == null)
+                {
+                    throw new VContainerException(ImplementationType, $"Component {ImplementationType} is not in this scene {destination.Scene.path}");
+                }
             }
             else
             {
-                var name = string.IsNullOrEmpty(destination.NewGameObjectName)
-                    ? ImplementationType.Name
-                    : destination.NewGameObjectName;
-                var gameObject = new GameObject(name);
-                gameObject.SetActive(false);
-                if (parent != null)
-                {
-                    gameObject.transform.SetParent(parent);
-                }
-                component = gameObject.AddComponent(ImplementationType);
+                throw new VContainerException(ImplementationType, "Invalid Component find target");
             }
+
+            if (component is MonoBehaviour monoBehaviour)
+            {
+                injector.Inject(monoBehaviour, resolver, Parameters);
+            }
+            return component;
+        }
+
+        Component InstantiatePrefab(IObjectResolver resolver)
+        {
+            var parent = destination.GetParent();
+            if (destination.Prefab.gameObject.activeSelf)
+            {
+                destination.Prefab.gameObject.SetActive(false);
+            }
+            var component = UnityEngine.Object.Instantiate(destination.Prefab, parent);
+
+            injector.Inject(component, resolver, Parameters);
+            component.gameObject.SetActive(true);
+            return component;
+        }
+
+        Component InstantiateNewGameObject(IObjectResolver resolver)
+        {
+            var parent = destination.GetParent();
+            var name = string.IsNullOrEmpty(destination.NewGameObjectName)
+                ? ImplementationType.Name
+                : destination.NewGameObjectName;
+            var gameObject = new GameObject(name);
+            gameObject.SetActive(false);
+            if (parent != null)
+            {
+                gameObject.transform.SetParent(parent);
+            }
+            var component = gameObject.AddComponent(ImplementationType);
+
             injector.Inject(component, resolver, Parameters);
             component.gameObject.SetActive(true);
             return component;

--- a/VContainer/Assets/VContainer/Runtime/Unity/ComponentRegistration.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/ComponentRegistration.cs
@@ -118,7 +118,10 @@ namespace VContainer.Unity
             {
                 destination.Prefab.gameObject.SetActive(false);
             }
-            var component = UnityEngine.Object.Instantiate(destination.Prefab, parent);
+
+            var component = parent != null
+                ? UnityEngine.Object.Instantiate(destination.Prefab, parent)
+                : UnityEngine.Object.Instantiate(destination.Prefab);
 
             injector.Inject(component, resolver, Parameters);
             component.gameObject.SetActive(true);

--- a/VContainer/Assets/VContainer/Runtime/Unity/ComponentRegistrationBuilder.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/ComponentRegistrationBuilder.cs
@@ -1,34 +1,27 @@
 using System;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 using VContainer.Internal;
 
 namespace VContainer.Unity
 {
     public sealed class ComponentRegistrationBuilder : RegistrationBuilder
     {
+        readonly bool find;
+        readonly Scene scene;
+        readonly Component prefab;
+
         Transform parent;
         Func<Transform> parentFinder;
         string gameObjectName;
-        Component prefab;
-
-        ComponentRegistrationBuilder(
-            Type implementationType,
-            Lifetime lifetime,
-            List<Type> interfaceTypes = null)
-            : base(implementationType, lifetime, interfaceTypes)
-        {
-            InterfaceTypes = InterfaceTypes ?? new List<Type>();
-            InterfaceTypes.Add(typeof(MonoBehaviour));
-            InterfaceTypes.Add(ImplementationType);
-        }
 
         internal ComponentRegistrationBuilder(
             Component prefab,
             Type implementationType,
             Lifetime lifetime,
             List<Type> interfaceTypes = null)
-            : this(implementationType, lifetime, interfaceTypes)
+            : this(false, default, implementationType, lifetime, interfaceTypes)
         {
             this.prefab = prefab;
         }
@@ -38,15 +31,35 @@ namespace VContainer.Unity
             Type implementationType,
             Lifetime lifetime,
             List<Type> interfaceTypes = null)
-            : this(implementationType, lifetime, interfaceTypes)
+            : this(false, default, implementationType, lifetime, interfaceTypes)
         {
             this.gameObjectName = gameObjectName;
+        }
+
+        internal ComponentRegistrationBuilder(
+            Scene scene,
+            Type implementationType,
+            List<Type> interfaceTypes = null)
+            : this(true, scene, implementationType, Lifetime.Scoped, interfaceTypes)
+        {
+        }
+
+        ComponentRegistrationBuilder(
+            bool find,
+            Scene scene,
+            Type implementationType,
+            Lifetime lifetime,
+            List<Type> interfaceTypes = null)
+            : base(implementationType, lifetime, interfaceTypes)
+        {
+            this.find = find;
+            this.scene = scene;
         }
 
         public override IRegistration Build()
         {
             var injector = InjectorCache.GetOrBuild(ImplementationType);
-            var destination = new ComponentDestination(prefab, parent, parentFinder, gameObjectName);
+            var destination = new ComponentDestination(find, scene, parent, parentFinder, prefab, gameObjectName);
 
             return new ComponentRegistration(
                 ImplementationType,

--- a/VContainer/Assets/VContainer/Runtime/Unity/ContainerBuilderUnityExtensions.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/ContainerBuilderUnityExtensions.cs
@@ -106,31 +106,13 @@ namespace VContainer.Unity
             return registrationBuilder;
         }
 
-        public static RegistrationBuilder RegisterComponentInHierarchy<T>(this IContainerBuilder builder)
+        public static ComponentRegistrationBuilder RegisterComponentInHierarchy<T>(this IContainerBuilder builder)
         {
             var lifetimeScope = (LifetimeScope)builder.ApplicationOrigin;
             var scene = lifetimeScope.gameObject.scene;
-            var component = default(T);
 
-            var gameObjectBuffer = UnityEngineObjectListBuffer<GameObject>.Get();
-            scene.GetRootGameObjects(gameObjectBuffer);
-            foreach (var gameObject in gameObjectBuffer)
-            {
-                component = gameObject.GetComponentInChildren<T>(true);
-                if (component != null) break;
-            }
-
-            if (component == null)
-            {
-                throw new VContainerException(typeof(T), $"Component {typeof(T)} is not in this scene {scene.path}");
-            }
-
-            var registrationBuilder = builder.RegisterInstance(component).As(typeof(T));
-            if (component is MonoBehaviour monoBehaviour)
-            {
-                registrationBuilder.As<MonoBehaviour>();
-                builder.RegisterBuildCallback(container => container.Inject(monoBehaviour));
-            }
+            var registrationBuilder = new ComponentRegistrationBuilder(scene, typeof(T));
+            builder.Register(registrationBuilder);
             return registrationBuilder;
         }
 

--- a/VContainer/Assets/VContainer/Runtime/Unity/ContainerBuilderUnityExtensions.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/ContainerBuilderUnityExtensions.cs
@@ -42,31 +42,19 @@ namespace VContainer.Unity
             return containerBuilder.RegisterComponent(component);
         }
 
-        public RegistrationBuilder AddInHierarchy<T>() where T : Component
-        {
-            var registrationBuilder = containerBuilder.RegisterComponentInHierarchy<T>();
-            if (parentTransform != null)
-                registrationBuilder.UnderTransform(parentTransform);
-            return registrationBuilder;
-        }
+        public ComponentRegistrationBuilder AddInHierarchy<T>()
+            => containerBuilder.RegisterComponentInHierarchy<T>()
+                .UnderTransform(parentTransform);
 
         public ComponentRegistrationBuilder AddOnNewGameObject<T>(Lifetime lifetime, string newGameObjectName = null)
             where T : Component
-        {
-            var registrationBuilder = containerBuilder.RegisterComponentOnNewGameObject<T>(lifetime, newGameObjectName);
-            if (parentTransform != null)
-                registrationBuilder.UnderTransform(parentTransform);
-            return registrationBuilder;
-        }
+            => containerBuilder.RegisterComponentOnNewGameObject<T>(lifetime, newGameObjectName)
+                .UnderTransform(parentTransform);
 
         public ComponentRegistrationBuilder AddInNewPrefab<T>(T prefab, Lifetime lifetime)
             where T : Component
-        {
-            var registrationBuilder = containerBuilder.RegisterComponentInNewPrefab(prefab, lifetime);
-            if (parentTransform != null)
-                registrationBuilder.UnderTransform(parentTransform);
-            return registrationBuilder;
-        }
+            => containerBuilder.RegisterComponentInNewPrefab(prefab, lifetime)
+                .UnderTransform(parentTransform);
     }
 
     public static class ContainerBuilderUnityExtensions

--- a/VContainer/Assets/VContainer/Runtime/Unity/EntryPointExceptionHandler.cs.meta
+++ b/VContainer/Assets/VContainer/Runtime/Unity/EntryPointExceptionHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3b60c8fd4709435d82c04a947e096fa3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VContainer/Assets/VContainer/Runtime/Unity/EntryPointExceptionHandler.cs.meta
+++ b/VContainer/Assets/VContainer/Runtime/Unity/EntryPointExceptionHandler.cs.meta
@@ -1,3 +1,0 @@
-﻿fileFormatVersion: 2
-guid: 3b60c8fd4709435d82c04a947e096fa3
-timeCreated: 1612005912

--- a/VContainer/Assets/VContainer/Runtime/Unity/LifetimeScope.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/LifetimeScope.cs
@@ -50,8 +50,8 @@ namespace VContainer.Unity
             return newScope;
         }
 
-        public static LifetimeScope Create(Action<IContainerBuilder> installation)
-            => Create(new ActionInstaller(installation));
+        public static LifetimeScope Create(Action<IContainerBuilder> configuration)
+            => Create(new ActionInstaller(configuration));
 
         public static ParentOverrideScope EnqueueParent(LifetimeScope parent)
             => new ParentOverrideScope(parent);

--- a/VContainer/Assets/VContainer/Runtime/Unity/UnityEngineObjectListBuffer.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/UnityEngineObjectListBuffer.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace VContainer.Internal
+namespace VContainer.Unity
 {
     static class UnityEngineObjectListBuffer<T> where T : UnityEngine.Object
     {

--- a/VContainer/Assets/VContainer/Tests/Unity/UnityContainerBuilderTest.cs
+++ b/VContainer/Assets/VContainer/Tests/Unity/UnityContainerBuilderTest.cs
@@ -56,7 +56,6 @@ namespace VContainer.Tests.Unity
         [Test]
         public void RegisterComponentInHierarchy()
         {
-            var lifetimeScope = new GameObject("LifetimeScope").AddComponent<LifetimeScope>();
             var go1 = new GameObject("Parent");
             var go2 = new GameObject("Child A");
             var go3 = new GameObject("Child B");
@@ -66,12 +65,13 @@ namespace VContainer.Tests.Unity
 
             go3.AddComponent<SampleMonoBehaviour>();
 
-            var builder = new ContainerBuilder { ApplicationOrigin = lifetimeScope };
-            builder.Register<ServiceA>(Lifetime.Transient);
-            builder.RegisterComponentInHierarchy<SampleMonoBehaviour>();
+            var lifetimeScope = LifetimeScope.Create(builder =>
+            {
+                builder.Register<ServiceA>(Lifetime.Transient);
+                builder.RegisterComponentInHierarchy<SampleMonoBehaviour>();
+            });
 
-            var container = builder.Build();
-            var resolved = container.Resolve<SampleMonoBehaviour>();
+            var resolved = lifetimeScope.Container.Resolve<SampleMonoBehaviour>();
 
             Assert.That(resolved, Is.InstanceOf<SampleMonoBehaviour>());
             Assert.That(resolved.ServiceA, Is.InstanceOf<ServiceA>());
@@ -122,68 +122,59 @@ namespace VContainer.Tests.Unity
         [Test]
         public void RegisterComponentInHierarchyWithBuiltinType()
         {
-            var lifetimeScope = new GameObject("LifetimeScope").AddComponent<LifetimeScope>();
             var go1 = new GameObject("Parent");
-
             go1.AddComponent<BoxCollider>();
 
-            var builder = new ContainerBuilder { ApplicationOrigin = lifetimeScope };
-            builder.Register<ServiceA>(Lifetime.Transient);
-            builder.RegisterComponentInHierarchy<BoxCollider>();
+            var lifetimeScope = LifetimeScope.Create(builder =>
+            {
+                builder.Register<ServiceA>(Lifetime.Transient);
+                builder.RegisterComponentInHierarchy<BoxCollider>();
+            });
 
-            var container = builder.Build();
-            var resolved = container.Resolve<BoxCollider>();
-
+            var resolved = lifetimeScope.Container.Resolve<BoxCollider>();
             Assert.That(resolved, Is.InstanceOf<BoxCollider>());
         }
 
         [Test]
         public void RegisterComponentOnNewGameObject()
         {
-            {
-                var go1 = new GameObject("Parent");
-                var builder = new ContainerBuilder();
-                builder.Register<ServiceA>(Lifetime.Transient);
-                builder.RegisterComponentOnNewGameObject<SampleMonoBehaviour>(Lifetime.Transient, "hoge")
-                    .UnderTransform(go1.transform);
+            var builder = new ContainerBuilder();
+            builder.Register<ServiceA>(Lifetime.Transient);
+            builder.RegisterComponentOnNewGameObject<SampleMonoBehaviour>(Lifetime.Scoped, "hoge");
 
-                var container = builder.Build();
-                var resolved1 = container.Resolve<SampleMonoBehaviour>();
-                var resolved2 = container.Resolve<SampleMonoBehaviour>();
+            var container = builder.Build();
+            var resolved1 = container.Resolve<SampleMonoBehaviour>();
+            var resolved2 = container.Resolve<SampleMonoBehaviour>();
+            Assert.That(resolved1.gameObject.name, Is.EqualTo("hoge"));
+            Assert.That(resolved2.gameObject.name, Is.EqualTo("hoge"));
+            Assert.That(resolved1, Is.InstanceOf<SampleMonoBehaviour>());
+            Assert.That(resolved2, Is.InstanceOf<SampleMonoBehaviour>());
+            Assert.That(resolved1.transform.parent, Is.Null);
+            Assert.That(resolved2.transform.parent, Is.Null);
+            Assert.That(resolved1, Is.EqualTo(resolved2));
+        }
 
-                Assert.That(resolved1.gameObject.name, Is.EqualTo("hoge"));
-                Assert.That(resolved2.gameObject.name, Is.EqualTo("hoge"));
-                Assert.That(resolved1, Is.InstanceOf<SampleMonoBehaviour>());
-                Assert.That(resolved2, Is.InstanceOf<SampleMonoBehaviour>());
-                Assert.That(resolved1.transform.parent, Is.EqualTo(go1.transform));
-                Assert.That(resolved2.transform.parent, Is.EqualTo(go1.transform));
-                Assert.That(resolved1, Is.Not.EqualTo(resolved2));
-            }
+        [Test]
+        public void RegisterComponentOnNewGameObjectUnderTransform()
+        {
+            var go1 = new GameObject("Parent");
 
-            {
-                var builder = new ContainerBuilder();
-                builder.Register<ServiceA>(Lifetime.Transient);
-                builder.RegisterComponentOnNewGameObject<SampleMonoBehaviour>(Lifetime.Scoped, "hoge");
+            var builder = new ContainerBuilder();
+            builder.Register<ServiceA>(Lifetime.Transient);
+            builder.RegisterComponentOnNewGameObject<SampleMonoBehaviour>(Lifetime.Transient, "hoge")
+                .UnderTransform(go1.transform);
 
-                var container = builder.Build();
-                var resolved1 = container.Resolve<SampleMonoBehaviour>();
-                var resolved2 = container.Resolve<SampleMonoBehaviour>();
-                Assert.That(resolved1.gameObject.name, Is.EqualTo("hoge"));
-                Assert.That(resolved2.gameObject.name, Is.EqualTo("hoge"));
-                Assert.That(resolved1, Is.InstanceOf<SampleMonoBehaviour>());
-                Assert.That(resolved2, Is.InstanceOf<SampleMonoBehaviour>());
-                Assert.That(resolved1.transform.parent, Is.Null);
-                Assert.That(resolved2.transform.parent, Is.Null);
-                Assert.That(resolved1, Is.EqualTo(resolved2));
-            }
-            {
-                var builder = new ContainerBuilder();
-                builder.Register<ServiceA>(Lifetime.Transient);
-                builder.RegisterComponentOnNewGameObject<SampleMonoBehaviour>(Lifetime.Scoped, "hoge");
+            var container = builder.Build();
+            var resolved1 = container.Resolve<SampleMonoBehaviour>();
+            var resolved2 = container.Resolve<SampleMonoBehaviour>();
 
-                var container = builder.Build();
-                Assert.That(container.Resolve<SampleMonoBehaviour>(), Is.InstanceOf<SampleMonoBehaviour>());
-            }
+            Assert.That(resolved1.gameObject.name, Is.EqualTo("hoge"));
+            Assert.That(resolved2.gameObject.name, Is.EqualTo("hoge"));
+            Assert.That(resolved1, Is.InstanceOf<SampleMonoBehaviour>());
+            Assert.That(resolved2, Is.InstanceOf<SampleMonoBehaviour>());
+            Assert.That(resolved1.transform.parent, Is.EqualTo(go1.transform));
+            Assert.That(resolved2.transform.parent, Is.EqualTo(go1.transform));
+            Assert.That(resolved1, Is.Not.EqualTo(resolved2));
         }
 
         [Test]
@@ -234,6 +225,44 @@ namespace VContainer.Tests.Unity
                 var container = builder.Build();
                 Assert.That(container.Resolve<SampleMonoBehaviour>(), Is.InstanceOf<SampleMonoBehaviour>());
             }
+        }
+
+        [Test]
+        public void UseComponentsWithParentTransform()
+        {
+            var go1 = new GameObject("Parent");
+            var go2 = new GameObject("Child A");
+            var go3 = new GameObject("Child B");
+
+            go3.transform.SetParent(go2.transform);
+            go2.transform.SetParent(go1.transform);
+
+            go1.AddComponent<SampleMonoBehaviour>();
+            go3.AddComponent<SampleMonoBehaviour>();
+
+            var lifetimeScope = LifetimeScope.Create(builder =>
+            {
+                builder.Register<ServiceA>(Lifetime.Scoped);
+                builder.Register<ServiceB>(Lifetime.Scoped);
+
+                builder.UseComponents(go2.transform, components =>
+                {
+                    components.AddInHierarchy<SampleMonoBehaviour>();
+                });
+
+                builder.UseComponents(go3.transform, components =>
+                {
+                    components.AddOnNewGameObject<SampleMonoBehaviour2>(Lifetime.Scoped);
+                });
+            });
+
+            var found = lifetimeScope.Container.Resolve<SampleMonoBehaviour>();
+            Assert.That(found, Is.InstanceOf<SampleMonoBehaviour>());
+            Assert.That(found.transform.parent, Is.EqualTo(go2.transform));
+
+            var created = lifetimeScope.Container.Resolve<SampleMonoBehaviour2>();
+            Assert.That(created, Is.InstanceOf<SampleMonoBehaviour2>());
+            Assert.That(created.transform.parent, Is.EqualTo(go3.transform));
         }
 
         [UnityTest]

--- a/website/docs/registering/register-monobehaviour.mdx
+++ b/website/docs/registering/register-monobehaviour.mdx
@@ -54,9 +54,13 @@ builder.RegisterComponentInHierarchy<YourBehaviour>()
 ## Register component to specific parent Transform
 
 ```csharp
+// Instantiate under the specified transform
 builder.RegisterComponentFromInNewPrefab<YourBehaviour>(Lifetime.Scoped)
     .UnderTransform(parent);
 
+// Find the component under the specified transform.
+builder.RegisterComponentInHierarchy<YourBehaviour>()
+    .UnderTransform(parent);
 ```
 
 Or find at runtime.

--- a/website/docs/registering/register-monobehaviour.mdx
+++ b/website/docs/registering/register-monobehaviour.mdx
@@ -83,7 +83,7 @@ builder.UseComponents(components =>
     components.AddInHierarchy<YourBehaviour>();
     components.AddFromNewPrefab(prefab, Lifetime.Scoped);
     components.AddOnNewGameObject<YourBehaviour>(Lifetime.Scoped, "name");
-})
+});
 ```
 
 This is the same as:
@@ -94,6 +94,33 @@ builder.RegisterComponentInHierarchy<YourBehaviour>();
 builder.RegisterComponentFromNewPrefab(prefab, Lifetime.Scoped);
 builder.RegisterComponentOnNewGameObject<YourBehaviour>(Lifetime.Scoped, "name");
 ```
+
+You can create a group with a specified parent.
+
+```csharp
+builder.UseComponents(parentTransform, components =>
+{
+    // GetComponentInChildren under `parentTransform`
+    components.AddInHierarchy<YourBehaviour>();
+
+    // Instantiate under `parentTransform`
+    components.AddFromNewPrefab(prefab, Lifetime.Scoped);
+    components.AddOnNewGameObject<YourBehaviour>(Lifetime.Scoped, "name");
+})
+```
+
+This is the same as:
+
+```csharp
+builder.RegisterComponentInHierarchy<YourBehaviour>()
+    .UnderTransform(parentTransform);
+
+builder.RegisterComponentFromNewPrefab(prefab, Lifetime.Scoped)
+    .UnderTransform(parentTransform);
+builder.RegisterComponentOnNewGameObject<YourBehaviour>(Lifetime.Scoped, "name");
+    .UnderTransform(parentTransform);
+```
+
 
 ## Execute only Inject for MonoBehaviour on the scene
 


### PR DESCRIPTION
## RegisterComponentInHierarchy with finding under specific parent transform

```csharp
builder.RegisterComponentInHIerarchy<ComponentA>()
    .UnderTransform(parent); 
```

## Add UseComponents with specific parent transform

```csharp
builder.UseComponents(parentTransform, components =>
{
    // GetComponentInChildren under `parentTransform`
    components.AddInHierarchy<YourBehaviour>();

    // Instantiate under `parentTransform`
    components.AddFromNewPrefab(prefab, Lifetime.Scoped);
    components.AddOnNewGameObject<YourBehaviour>(Lifetime.Scoped, "name");
})
```

This is the same as:

```csharp
builder.RegisterComponentInHierarchy<YourBehaviour>()
    .UnderTransform(parentTransform);

builder.RegisterComponentFromNewPrefab(prefab, Lifetime.Scoped)
    .UnderTransform(parentTransform);
builder.RegisterComponentOnNewGameObject<YourBehaviour>(Lifetime.Scoped, "name");
    .UnderTransform(parentTransform);
```