### PR TITLE
Restore prefab state after instantiation

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/Unity/ComponentRegistration.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/ComponentRegistration.cs
@@ -114,6 +114,7 @@ namespace VContainer.Unity
         Component InstantiatePrefab(IObjectResolver resolver)
         {
             var parent = destination.GetParent();
+            var wasActive = destination.Prefab.gameObject.activeSelf;
             if (destination.Prefab.gameObject.activeSelf)
             {
                 destination.Prefab.gameObject.SetActive(false);
@@ -123,6 +124,7 @@ namespace VContainer.Unity
                 ? UnityEngine.Object.Instantiate(destination.Prefab, parent)
                 : UnityEngine.Object.Instantiate(destination.Prefab);
 
+            destination.Prefab.gameObject.SetActive(wasActive);
             injector.Inject(component, resolver, Parameters);
             component.gameObject.SetActive(true);
             return component;

--- a/VContainer/Assets/VContainer/Runtime/Unity/LifetimeScope.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/LifetimeScope.cs
@@ -203,12 +203,14 @@ namespace VContainer.Unity
 
         public LifetimeScope CreateChildFromPrefab(LifetimeScope prefab, IInstaller installer = null)
         {
+            var wasActive = prefab.gameObject.activeSelf;
             if (prefab.gameObject.activeSelf && prefab.autoRun)
             {
                 prefab.gameObject.SetActive(false);
             }
 
             var child = Instantiate(prefab, transform, false);
+            prefab.gameObject.SetActive(wasActive);
             if (installer != null)
             {
                 child.extraInstallers.Add(installer);


### PR DESCRIPTION
Instantiated prefab itself (not clone in the scene) remains inactive even after play mode.
This PR restore prefab state just after instantiation.

If that's not inteded, just drop this PR 😃