### PR TITLE
Unity.VContainer.CodeGen.asmdef is Editor Assembly

### DIFF
--- a/VContainer/Assets/VContainer/Editor/CodeGen/Unity.VContainer.CodeGen.asmdef
+++ b/VContainer/Assets/VContainer/Editor/CodeGen/Unity.VContainer.CodeGen.asmdef
@@ -4,7 +4,9 @@
     "references": [
         "VContainer"
     ],
-    "includePlatforms": [],
+    "includePlatforms": [
+        "Editor"
+    ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": true,


### PR DESCRIPTION
`Unity.VContainer.CodeGen` は（現状では）エディタスクリプト用のアセンブリであるため、それを明示してはいかがでしょうか？