### PR TITLE
Make sure Assembly-CSharp is not a target of CodeGen

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/CodeGen/VContainer.EnableCodeGen.asmdef
+++ b/VContainer/Assets/VContainer/Runtime/CodeGen/VContainer.EnableCodeGen.asmdef
@@ -1,3 +1,14 @@
 {
-	"name": "VContainer.EnableCodeGen"
+    "name": "VContainer.EnableCodeGen",
+    "rootNamespace": "",
+    "references": [],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": false,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": true
 }


### PR DESCRIPTION
Currently, any assembly that references `VContainer.EnableCodeGen` is a target of CodeGen optimization.

I noticed that Assembly-CSharp is targeted by default.
Since this is unnecessary and may lead to unintended behavior, we will disable CodeGen by default.