### PR TITLE
Change the lifetime of RegisterInstance to Singleton.

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/Container.cs
+++ b/VContainer/Assets/VContainer/Runtime/Container.cs
@@ -11,7 +11,6 @@ namespace VContainer
         object Resolve(IRegistration registration);
         IScopedObjectResolver CreateScope(Action<IContainerBuilder> installation = null);
         void Inject(object instance);
-        void Inject(object instance, params IInjectParameter[] parameters);
     }
 
     public interface IScopedObjectResolver : IObjectResolver
@@ -93,12 +92,6 @@ namespace VContainer
         {
             var injector = InjectorCache.GetOrBuild(instance.GetType());
             injector.Inject(instance, this, null);
-        }
-
-        public void Inject(object instance, params IInjectParameter[] parameters)
-        {
-            var injector = InjectorCache.GetOrBuild(instance.GetType());
-            injector.Inject(instance, this, parameters);
         }
 
         public bool TryGetRegistration(Type type, out IRegistration registration)

--- a/VContainer/Assets/VContainer/Runtime/RegistrationBuilder.cs
+++ b/VContainer/Assets/VContainer/Runtime/RegistrationBuilder.cs
@@ -25,7 +25,7 @@ namespace VContainer
         public RegistrationBuilder(object instance)
         {
             ImplementationType = instance.GetType();
-            Lifetime = Lifetime.Scoped;
+            Lifetime = Lifetime.Singleton;
             SpecificInstance = instance;
         }
 
@@ -56,8 +56,7 @@ namespace VContainer
 
         public RegistrationBuilder AsSelf()
         {
-            InterfaceTypes = InterfaceTypes ?? new List<Type>();
-            InterfaceTypes.Add(ImplementationType);
+            AddInterfaceType(ImplementationType);
             return this;
         }
 
@@ -91,8 +90,10 @@ namespace VContainer
 
         public RegistrationBuilder As(params Type[] interfaceTypes)
         {
-            InterfaceTypes = InterfaceTypes ?? new List<Type>();
-            InterfaceTypes.AddRange(interfaceTypes);
+            foreach (var interfaceType in interfaceTypes)
+            {
+                AddInterfaceType(interfaceType);
+            }
             return this;
         }
 
@@ -128,7 +129,8 @@ namespace VContainer
                 throw new VContainerException(interfaceType, $"{ImplementationType.FullName} is not assignable from {interfaceType.FullName}");
             }
             InterfaceTypes = InterfaceTypes ?? new List<Type>();
-            InterfaceTypes.Add(interfaceType);
+            if (!InterfaceTypes.Contains(interfaceType))
+                InterfaceTypes.Add(interfaceType);
         }
    }
 }

--- a/VContainer/Assets/VContainer/Tests/ScopedContainerTest.cs
+++ b/VContainer/Assets/VContainer/Tests/ScopedContainerTest.cs
@@ -199,5 +199,31 @@ namespace VContainer.Tests
             var ctorInjectable = new ServiceA(new NoDependencyServiceA());
             Assert.DoesNotThrow(() => childContainer.Inject(ctorInjectable));
         }
+
+
+        [Test]
+        public void RegisterDisposableInstance()
+        {
+            var instance1 = new DisposableServiceA();
+
+            var builder = new ContainerBuilder();
+            builder.RegisterInstance(instance1);
+
+            var container = builder.Build();
+            var childContainer = container.CreateScope();
+
+            var resolveFromParent = container.Resolve<DisposableServiceA>();
+            var resolveFromChild = childContainer.Resolve<DisposableServiceA>();
+
+            Assert.That(resolveFromParent, Is.InstanceOf<DisposableServiceA>());
+            Assert.That(resolveFromChild, Is.InstanceOf<DisposableServiceA>());
+            Assert.That(resolveFromParent, Is.EqualTo(resolveFromChild));
+
+            childContainer.Dispose();
+            Assert.That(resolveFromParent.Disposed, Is.False);
+
+            container.Dispose();
+            Assert.That(resolveFromParent.Disposed, Is.True);
+        }
     }
 }


### PR DESCRIPTION
Refs: #169

There is a problem that when a registered instance of RegisterInstance is resolved by a child, and the child container is destroyed, the parent instance will also be disposed.

The easiest way to fix this behavior is to change to Singleton.

