### PR TITLE
Fix circular references in assemblies that ran CodeGen

### DIFF
--- a/VContainer/Assets/VContainer/Editor/CodeGen/InjectionILGenerator.cs
+++ b/VContainer/Assets/VContainer/Editor/CodeGen/InjectionILGenerator.cs
@@ -12,7 +12,7 @@ using VContainer.Internal;
 
 namespace VContainer.Editor.CodeGen
 {
-    public sealed class InjectionILGenerator
+    sealed class InjectionILGenerator
     {
         readonly ModuleDefinition module;
         readonly IList<string> targetNamespaces;
@@ -198,7 +198,6 @@ namespace VContainer.Editor.CodeGen
             var injectMethodDef = injectorTypeDef.Methods.Single(x => x.Name == "Inject");
 
             injectorTypeDef.Methods.Add(methodDef);
-
 
             methodDef.Parameters.Add(new ParameterDefinition(ObjectResolverTypeRef)
             {

--- a/VContainer/Assets/VContainer/Editor/CodeGen/VContainerILPostProcessor.cs
+++ b/VContainer/Assets/VContainer/Editor/CodeGen/VContainerILPostProcessor.cs
@@ -35,6 +35,16 @@ namespace VContainer.Editor.CodeGen
                     return new ILPostProcessResult(null, diagnosticMessages);
                 }
 
+                // TODO:
+                var (selfReference, selfReferenceIndex) = assemblyDefinition.MainModule.AssemblyReferences
+                    .Select((x, i) => (x, i))
+                    .FirstOrDefault(e => e.x.Name == assemblyDefinition.Name.Name);
+
+                if (selfReference != null)
+                {
+                    assemblyDefinition.MainModule.AssemblyReferences.RemoveAt(selfReferenceIndex);
+                }
+
                 var pe = new MemoryStream();
                 var pdb = new MemoryStream();
                 var writerParameters = new WriterParameters


### PR DESCRIPTION
In Mono.Cecil, when a module does an ImportReference of its own type, it seems to add its own reference to the assembly.

Here is a hot fix to remove the self-reference

Refs: #167 