### PR TITLE
Make sure RegisterEntryPoint default lifetime is .Singleton

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/Unity/ContainerBuilderUnityExtensions.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/ContainerBuilderUnityExtensions.cs
@@ -80,7 +80,7 @@ namespace VContainer.Unity
             configuration(new ComponentsBuilder(builder, root));
         }
 
-        public static RegistrationBuilder RegisterEntryPoint<T>(this IContainerBuilder builder, Lifetime lifetime)
+        public static RegistrationBuilder RegisterEntryPoint<T>(this IContainerBuilder builder, Lifetime lifetime = Lifetime.Singleton)
         {
             if (!builder.Exists(typeof(EntryPointDispatcher), false))
             {

--- a/VContainer/Assets/VContainer/Tests/Unity/EntryPointTest.cs
+++ b/VContainer/Assets/VContainer/Tests/Unity/EntryPointTest.cs
@@ -12,7 +12,7 @@ namespace VContainer.Tests.Unity
         {
             var lifetimeScope = LifetimeScope.Create(builder =>
             {
-                builder.RegisterEntryPoint<SampleEntryPoint>(Lifetime.Scoped).AsSelf();
+                builder.RegisterEntryPoint<SampleEntryPoint>().AsSelf();
                 builder.Register<DisposableServiceA>(Lifetime.Scoped);
             });
 
@@ -64,8 +64,8 @@ namespace VContainer.Tests.Unity
 
             LifetimeScope.Create(builder =>
             {
-                builder.RegisterEntryPoint<InitializableThrowable>(Lifetime.Scoped);
-                builder.RegisterEntryPointExceptionHandler(ex => { handled += 1; });
+                builder.RegisterEntryPoint<InitializableThrowable>();
+                builder.RegisterEntryPointExceptionHandler(ex => handled += 1);
             });
 
             yield return null;
@@ -81,7 +81,7 @@ namespace VContainer.Tests.Unity
 
             LifetimeScope.Create(builder =>
             {
-                builder.RegisterEntryPoint<PostInitializableThrowable>(Lifetime.Scoped);
+                builder.RegisterEntryPoint<PostInitializableThrowable>();
                 builder.RegisterEntryPointExceptionHandler(ex => { handled += 1; });
             });
 
@@ -98,7 +98,7 @@ namespace VContainer.Tests.Unity
 
             LifetimeScope.Create(builder =>
             {
-                builder.RegisterEntryPoint<StartableThrowable>(Lifetime.Scoped);
+                builder.RegisterEntryPoint<StartableThrowable>();
                 builder.RegisterEntryPointExceptionHandler(ex => { handled += 1; });
             });
 
@@ -115,7 +115,7 @@ namespace VContainer.Tests.Unity
 
             LifetimeScope.Create(builder =>
             {
-                builder.RegisterEntryPoint<PostStartableThrowable>(Lifetime.Scoped);
+                builder.RegisterEntryPoint<PostStartableThrowable>();
                 builder.RegisterEntryPointExceptionHandler(ex => { handled += 1; });
             });
 
@@ -132,7 +132,7 @@ namespace VContainer.Tests.Unity
 
             LifetimeScope.Create(builder =>
             {
-                builder.RegisterEntryPoint<TickableThrowable>(Lifetime.Scoped);
+                builder.RegisterEntryPoint<TickableThrowable>();
                 builder.RegisterEntryPointExceptionHandler(ex => { handled += 1; });
             });
 
@@ -149,8 +149,8 @@ namespace VContainer.Tests.Unity
 
             LifetimeScope.Create(builder =>
             {
-                builder.RegisterEntryPoint<PostTickableThrowable>(Lifetime.Scoped);
-                builder.RegisterEntryPointExceptionHandler(ex => { handled += 1; });
+                builder.RegisterEntryPoint<PostTickableThrowable>();
+                builder.RegisterEntryPointExceptionHandler(ex => handled += 1);
             });
 
             yield return null;
@@ -166,8 +166,8 @@ namespace VContainer.Tests.Unity
 
             LifetimeScope.Create(builder =>
             {
-                builder.RegisterEntryPoint<LateTickableThrowable>(Lifetime.Scoped);
-                builder.RegisterEntryPointExceptionHandler(ex => { handled += 1; });
+                builder.RegisterEntryPoint<LateTickableThrowable>();
+                builder.RegisterEntryPointExceptionHandler(ex => handled += 1);
             });
 
             yield return null;
@@ -183,8 +183,8 @@ namespace VContainer.Tests.Unity
 
             LifetimeScope.Create(builder =>
             {
-                builder.RegisterEntryPoint<PostLateTickableThrowable>(Lifetime.Scoped);
-                builder.RegisterEntryPointExceptionHandler(ex => { handled += 1; });
+                builder.RegisterEntryPoint<PostLateTickableThrowable>();
+                builder.RegisterEntryPointExceptionHandler(ex => handled += 1);
             });
 
             yield return null;

--- a/VContainer/Assets/VContainer/Tests/Unity/Fixtures/SampleEntryPoint.cs
+++ b/VContainer/Assets/VContainer/Tests/Unity/Fixtures/SampleEntryPoint.cs
@@ -37,6 +37,41 @@ namespace VContainer.Tests.Unity
         void IPostLateTickable.PostLateTick() => PostLateTickCalls += 1;
     }
 
+    public class SampleEntryPoint2 :
+        IInitializable,
+        IPostInitializable,
+        IStartable,
+        IPostStartable,
+        IFixedTickable,
+        IPostFixedTickable,
+        ITickable,
+        IPostTickable,
+        ILateTickable,
+        IPostLateTickable
+    {
+        public int InitializeCalled;
+        public int PostInitializeCalled;
+        public int StartCalled;
+        public int PostStartCalled;
+        public int FixedTickCalls;
+        public int PostFixedTickCalls;
+        public int TickCalls;
+        public int PostTickCalls;
+        public int LateTickCalls;
+        public int PostLateTickCalls;
+
+        void IInitializable.Initialize() => InitializeCalled += 1;
+        void IPostInitializable.PostInitialize() => PostInitializeCalled += 1;
+        void IStartable.Start() => StartCalled += 1;
+        void IPostStartable.PostStart() => PostStartCalled += 1;
+        void IFixedTickable.FixedTick() => FixedTickCalls += 1;
+        void IPostFixedTickable.PostFixedTick() => PostFixedTickCalls += 1;
+        void ITickable.Tick() => TickCalls += 1;
+        void IPostTickable.PostTick() => PostTickCalls += 1;
+        void ILateTickable.LateTick() => LateTickCalls += 1;
+        void IPostLateTickable.PostLateTick() => PostLateTickCalls += 1;
+    }
+
     public class InitializableThrowable : IInitializable
     {
         public void Initialize()

--- a/VContainer/Assets/VContainer/Tests/Unity/LifetimeScopeTest.cs
+++ b/VContainer/Assets/VContainer/Tests/Unity/LifetimeScopeTest.cs
@@ -28,7 +28,7 @@ namespace VContainer.Tests.Unity
         {
             var lifetimeScope = LifetimeScope.Create(builder =>
             {
-                builder.RegisterEntryPoint<SampleEntryPoint>(Lifetime.Scoped).AsSelf();
+                builder.RegisterEntryPoint<SampleEntryPoint>().AsSelf();
                 builder.Register<DisposableServiceA>(Lifetime.Scoped);
             });
 
@@ -54,7 +54,7 @@ namespace VContainer.Tests.Unity
         {
             var parentLifetimeScope = LifetimeScope.Create(builder =>
             {
-                builder.RegisterEntryPoint<SampleEntryPoint>(Lifetime.Scoped).AsSelf();
+                builder.RegisterEntryPoint<SampleEntryPoint>().AsSelf();
             });
 
             yield return null;
@@ -71,7 +71,7 @@ namespace VContainer.Tests.Unity
 
             var childLifetimeScope = parentLifetimeScope.CreateChild(builder =>
             {
-                builder.RegisterEntryPoint<SampleEntryPoint>(Lifetime.Scoped).AsSelf();
+                builder.RegisterEntryPoint<SampleEntryPoint>().AsSelf();
                 builder.Register<DisposableServiceA>(Lifetime.Scoped);
             });
 
@@ -100,7 +100,7 @@ namespace VContainer.Tests.Unity
         {
             var parent = LifetimeScope.Create(builder =>
             {
-                builder.RegisterEntryPoint<SampleEntryPoint>(Lifetime.Singleton).AsSelf();
+                builder.RegisterEntryPoint<SampleEntryPoint>().AsSelf();
             });
 
             var childPrefab = new GameObject("Child").AddComponent<SampleChildLifetimeScope>();
@@ -121,7 +121,7 @@ namespace VContainer.Tests.Unity
         {
             var parent = LifetimeScope.Create(builder =>
             {
-                builder.RegisterEntryPoint<SampleEntryPoint>(Lifetime.Singleton).AsSelf();
+                builder.RegisterEntryPoint<SampleEntryPoint>().AsSelf();
             });
 
             var childPrefab = new GameObject("Child").AddComponent<SampleChildLifetimeScope>();
@@ -146,7 +146,7 @@ namespace VContainer.Tests.Unity
         {
             var parentLifetimeScope = LifetimeScope.Create(builder =>
             {
-                builder.RegisterEntryPoint<SampleEntryPoint>(Lifetime.Singleton).AsSelf();
+                builder.RegisterEntryPoint<SampleEntryPoint>().AsSelf();
             });
 
             var parentEntryPoint = parentLifetimeScope.Container.Resolve<SampleEntryPoint>();

--- a/VContainer/Assets/VContainer/Tests/Unity/UnityContainerBuilderTest.cs
+++ b/VContainer/Assets/VContainer/Tests/Unity/UnityContainerBuilderTest.cs
@@ -14,7 +14,7 @@ namespace VContainer.Tests.Unity
         public void RegisterEntryPoint()
         {
             var builder = new ContainerBuilder();
-            builder.RegisterEntryPoint<SampleEntryPoint>(Lifetime.Singleton);
+            builder.RegisterEntryPoint<SampleEntryPoint>();
 
             var container = builder.Build();
             Assert.That(container.Resolve<IInitializable>(), Is.InstanceOf<IInitializable>());
@@ -31,9 +31,8 @@ namespace VContainer.Tests.Unity
         public void RegisterEntryPointMultiple()
         {
             var builder = new ContainerBuilder();
-            builder.RegisterEntryPoint<SampleEntryPoint>(Lifetime.Scoped);
-            builder.RegisterEntryPoint<SampleEntryPoint>(Lifetime.Scoped);
-
+            builder.RegisterEntryPoint<SampleEntryPoint>();
+            builder.RegisterEntryPoint<SampleEntryPoint2>();
             var container = builder.Build();
             Assert.That(container.Resolve<IReadOnlyList<EntryPointDispatcher>>().Count, Is.EqualTo(1));
         }


### PR DESCRIPTION
I realized that EntryPoint is basically a singleton because it doesn't need to be resolved by others.