### PR TITLE
Fix an error in CodeGen that failed to get System.Type (Unity 2021)

### DIFF
--- a/VContainer/Assets/VContainer/Editor/CodeGen/VContainerILPostProcessor.cs
+++ b/VContainer/Assets/VContainer/Editor/CodeGen/VContainerILPostProcessor.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using Unity.CompilationPipeline.Common.Diagnostics;
 using Unity.CompilationPipeline.Common.ILPostProcessing;
 using Mono.Cecil;
@@ -25,8 +26,10 @@ namespace VContainer.Editor.CodeGen
             if (!WillProcess(compiledAssembly))
                 return null;
 
+            var assembly = Assembly.Load(compiledAssembly.InMemoryAssembly.PeData);
+
             var assemblyDefinition = Utils.LoadAssemblyDefinition(compiledAssembly);
-            var generator = new InjectionILGenerator(assemblyDefinition.MainModule, null);
+            var generator = new InjectionILGenerator(assemblyDefinition.MainModule, assembly, null);
 
             if (generator.TryGenerate(out var diagnosticMessages))
             {

--- a/VContainer/Assets/VContainer/Editor/CodeGen/VContainerILPostProcessor.cs
+++ b/VContainer/Assets/VContainer/Editor/CodeGen/VContainerILPostProcessor.cs
@@ -26,10 +26,8 @@ namespace VContainer.Editor.CodeGen
             if (!WillProcess(compiledAssembly))
                 return null;
 
-            var assembly = Assembly.Load(compiledAssembly.InMemoryAssembly.PeData);
-
             var assemblyDefinition = Utils.LoadAssemblyDefinition(compiledAssembly);
-            var generator = new InjectionILGenerator(assemblyDefinition.MainModule, assembly, null);
+            var generator = new InjectionILGenerator(assemblyDefinition.MainModule, compiledAssembly, null);
 
             if (generator.TryGenerate(out var diagnosticMessages))
             {


### PR DESCRIPTION
#187 
Unity 2021 seems to give an error when building with CodeGen. (You can run it in the editor).

The probrem:
- System.Type.GetType in CodeGen is broken. Probably the assembly to be compiled cannot be referenced at build time.
 
Fix:
- Try to use Assembly.Load when Assembly cannot be referenced