### PR TITLE
 Support dynamic registration from open generic type

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/ContainerBuilderExtensions.cs
+++ b/VContainer/Assets/VContainer/Runtime/ContainerBuilderExtensions.cs
@@ -56,6 +56,32 @@ namespace VContainer
             TInterface1 instance)
             => builder.RegisterInstance(instance).As(typeof(TInterface1), typeof(TInterface2), typeof(TInterface3));
 
+        public static GenericFallbackRegistrationBuilder RegisterGeneric(
+            this IContainerBuilder builder,
+            Type openGenericImplementationType,
+            Lifetime lifetime)
+            => builder.Register(new GenericFallbackRegistrationBuilder(
+                openGenericImplementationType,
+                lifetime));
+
+        public static GenericFallbackRegistrationBuilder RegisterGeneric(
+            this IContainerBuilder builder,
+            Type openGenericInterfaceType,
+            Type openGenericImplementationType,
+            Lifetime lifetime)
+        {
+            if (!openGenericInterfaceType.IsGenericTypeDefinition)
+            {
+                throw new ArgumentException($"{openGenericInterfaceType} is not an open generic type");
+            }
+            var registrationBuilder = new GenericFallbackRegistrationBuilder(
+                openGenericImplementationType,
+                lifetime);
+            registrationBuilder.As(openGenericInterfaceType);
+            builder.Register(registrationBuilder);
+            return registrationBuilder;
+        }
+
         public static RegistrationBuilder RegisterFactory<T>(
             this IContainerBuilder builder,
             Func<T> factory)

--- a/VContainer/Assets/VContainer/Runtime/GenericFallbackRegistrationBuilder.cs
+++ b/VContainer/Assets/VContainer/Runtime/GenericFallbackRegistrationBuilder.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using VContainer.Internal;
+
+namespace VContainer
+{
+    public sealed class GenericFallbackRegistrationBuilder : RegistrationBuilder
+    {
+        bool asImplementedInterfaces;
+        bool asSelf;
+
+        public GenericFallbackRegistrationBuilder(Type implementationType, Lifetime lifetime)
+			: base(implementationType, lifetime)
+        {
+            if (!implementationType.IsGenericTypeDefinition)
+            {
+                throw new ArgumentException($"{implementationType} is not an open generic type");
+            }
+        }
+
+        public new GenericFallbackRegistrationBuilder AsImplementedInterfaces()
+        {
+            asImplementedInterfaces = true;
+            return this;
+        }
+
+        public new GenericFallbackRegistrationBuilder AsSelf()
+        {
+            asSelf = true;
+            return this;
+        }
+
+        public override IRegistration Build()
+        {
+            return new GenericFallbackRegistration(
+                ImplementationType,
+                Lifetime,
+                InterfaceTypes,
+                Parameters,
+                asImplementedInterfaces,
+                asSelf);
+        }
+	}
+}

--- a/VContainer/Assets/VContainer/Runtime/GenericFallbackRegistrationBuilder.cs.meta
+++ b/VContainer/Assets/VContainer/Runtime/GenericFallbackRegistrationBuilder.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 1aa7c2d2fd934281b2d99b36b1d82f46
+timeCreated: 1620127135

--- a/VContainer/Assets/VContainer/Runtime/Internal/GenericFallbackRegistration.cs
+++ b/VContainer/Assets/VContainer/Runtime/Internal/GenericFallbackRegistration.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+
+namespace VContainer.Internal
+{
+    sealed class GenericFallbackRegistration : IRegistration
+    {
+        public Type ImplementationType { get; }
+        public IReadOnlyList<Type> InterfaceTypes { get; }
+        public Lifetime Lifetime { get; }
+
+        readonly IReadOnlyList<IInjectParameter> parameters;
+        readonly bool asImplementedInterfaces;
+        readonly bool asSelf;
+
+        public GenericFallbackRegistration(
+            Type implementationType,
+            Lifetime lifetime,
+            IReadOnlyList<Type> interfaceTypes,
+            IReadOnlyList<IInjectParameter> parameters,
+            bool asImplementedInterfaces,
+            bool asSelf)
+        {
+            ImplementationType = implementationType;
+            Lifetime = lifetime;
+            InterfaceTypes = interfaceTypes;
+            this.parameters = parameters;
+            this.asImplementedInterfaces = asImplementedInterfaces;
+        }
+
+        public object SpawnInstance(IObjectResolver resolver) => throw new NotSupportedException();
+
+        public IRegistration BuildGenericRegistration(Type interfaceOpenGenericType, Type interfaceType)
+        {
+            if (!interfaceOpenGenericType.IsGenericTypeDefinition)
+            {
+                throw new ArgumentException(
+                    $"{nameof(interfaceOpenGenericType)} {interfaceOpenGenericType} is not an open generic.");
+            }
+
+            if (!interfaceType.IsConstructedGenericType)
+            {
+                throw new ArgumentException($"{nameof(interfaceType)} {interfaceType} is not a generic type");
+            }
+
+            var closedGenericType = interfaceOpenGenericType == ImplementationType
+                ? interfaceType
+                : ImplementationType.MakeGenericType(interfaceType.GetGenericArguments());
+
+            var injector = InjectorCache.GetOrBuild(closedGenericType);
+
+            return new Registration(
+                closedGenericType,
+                Lifetime,
+                new[] { interfaceType },
+                parameters,
+                injector);
+        }
+    }
+}

--- a/VContainer/Assets/VContainer/Runtime/Internal/GenericFallbackRegistration.cs.meta
+++ b/VContainer/Assets/VContainer/Runtime/Internal/GenericFallbackRegistration.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: d4a7ae3062d8431fbde86a07d9f99608
+timeCreated: 1620051358

--- a/VContainer/Assets/VContainer/Runtime/Internal/Registration.cs
+++ b/VContainer/Assets/VContainer/Runtime/Internal/Registration.cs
@@ -41,25 +41,23 @@ namespace VContainer.Internal
         public Lifetime Lifetime => Lifetime.Transient; // Collection refernce is transient. Members can have each lifetimes.
 
         readonly Type elementType;
-
-        readonly List<Type> interfaceTypes;
+        readonly Type[] interfaceTypes;
         readonly IList<IRegistration> registrations = new List<IRegistration>();
-
-        public CollectionRegistration(Type elementType) : this(
-            typeof(List<>).MakeGenericType(elementType),
-            elementType)
-        {
-        }
 
         public CollectionRegistration(Type listType, Type elementType)
         {
             this.elementType = elementType;
             ImplementationType = listType;
-            interfaceTypes = new List<Type>
+            interfaceTypes = new []
             {
                 typeof(IEnumerable<>).MakeGenericType(elementType),
                 typeof(IReadOnlyList<>).MakeGenericType(elementType),
             };
+        }
+
+        public CollectionRegistration(Type elementType)
+            : this(typeof(List<>).MakeGenericType(elementType), elementType)
+        {
         }
 
         public void Add(IRegistration registration)

--- a/VContainer/Assets/VContainer/Runtime/RegistrationBuilder.cs
+++ b/VContainer/Assets/VContainer/Runtime/RegistrationBuilder.cs
@@ -112,9 +112,10 @@ namespace VContainer
             return this;
         }
 
-        void AddInterfaceType(Type interfaceType)
+        protected void AddInterfaceType(Type interfaceType)
         {
-            if (!interfaceType.IsAssignableFrom(ImplementationType))
+            if (!ImplementationType.IsGenericTypeDefinition &&
+                !interfaceType.IsAssignableFrom(ImplementationType))
             {
                 throw new VContainerException(interfaceType, $"{ImplementationType.FullName} is not assignable from {interfaceType.FullName}");
             }

--- a/VContainer/Assets/VContainer/Tests/FactoryTest.cs
+++ b/VContainer/Assets/VContainer/Tests/FactoryTest.cs
@@ -3,16 +3,6 @@ using NUnit.Framework;
 
 namespace VContainer.Tests
 {
-    class Foo
-    {
-        public int Param1 { get; set; }
-        public int Param2 { get; set; }
-        public int Param3 { get; set; }
-        public int Param4 { get; set; }
-        public I2 Service2 { get; set; }
-        public I3 Service3 { get; set; }
-    }
-
     [TestFixture]
     public class FactoryTest
     {

--- a/VContainer/Assets/VContainer/Tests/Fixtures.cs
+++ b/VContainer/Assets/VContainer/Tests/Fixtures.cs
@@ -30,6 +30,29 @@ namespace VContainer.Tests
     {
     }
 
+    interface IOpenGenericService<T>
+    {
+        T InnerService1 { get; }
+        I2 InnerService2 { get; }
+    }
+
+    interface IOpenGenericService2<T1, T2>
+    {
+        T1 InnerService1 { get; }
+        T2 InnerService2 { get; }
+        I4 InnerService3 { get; }
+    }
+
+    interface IRequestHandler<TRequest>
+    {
+        void Execute(TRequest request);
+    }
+
+    interface IRequestHandler<TRequest, TResponse>
+    {
+        TResponse Execute(TRequest request);
+    }
+
     class AllInjectionFeatureService : I1
     {
         public bool ConstructorCalled;
@@ -225,23 +248,92 @@ namespace VContainer.Tests
         }
     }
 
-    class GenericsService<T>
+    class GenericService<T> : IOpenGenericService<T>
     {
-        public readonly I2 ParameterService;
+        public T InnerService1 { get; }
+        public I2 InnerService2 { get; }
 
-        public GenericsService(I2 parameterService)
+        public GenericService(T innerService, I2 innerService2)
         {
-            ParameterService = parameterService;
+            InnerService1 = innerService;
+            InnerService2 = innerService2;
+        }
+    }
+
+    class GenericService2<T1, T2> : IOpenGenericService2<T1, T2>
+    {
+        public T1 InnerService1 { get; }
+        public T2 InnerService2 { get; }
+        public I4 InnerService3 { get; }
+
+        public GenericService2(T1 innerService1, T2 innerService2, I4 innerService3)
+        {
+            InnerService1 = innerService1;
+            InnerService2 = innerService2;
+            InnerService3 = innerService3;
         }
     }
 
     class GenericsArgumentService
     {
-        public readonly GenericsService<I2> GenericsService;
+        public readonly GenericService<I2> GenericService;
 
-        public GenericsArgumentService(GenericsService<I2> genericsService)
+        public GenericsArgumentService(GenericService<I2> genericService)
         {
-            GenericsService = genericsService;
+            GenericService = genericService;
         }
+    }
+
+    class Foo
+    {
+        public int Param1 { get; set; }
+        public int Param2 { get; set; }
+        public int Param3 { get; set; }
+        public int Param4 { get; set; }
+        public I2 Service2 { get; set; }
+        public I3 Service3 { get; set; }
+    }
+
+    class Bar
+    {
+        public int X { get; set; }
+    }
+
+    class FooHandler : IRequestHandler<Foo>
+    {
+        public void Execute(Foo request)
+        {
+        }
+    }
+
+    class FooHandler2 : IRequestHandler<Foo>
+    {
+        public readonly I2 ParameterService;
+
+        public FooHandler2(I2 service2)
+        {
+            ParameterService = service2;
+        }
+
+        public void Execute(Foo request)
+        {
+        }
+    }
+
+    class FooBarHandler : IRequestHandler<Foo, Bar>
+    {
+        public Bar Execute(Foo request) => new Bar { X = 100 };
+    }
+
+    class FooBarHandler2 : IRequestHandler<Foo, Bar>
+    {
+        public readonly I2 service2;
+
+        public FooBarHandler2(I2 service2)
+        {
+            this.service2 = service2;
+        }
+
+        public Bar Execute(Foo request) => new Bar { X = 200 };
     }
 }


### PR DESCRIPTION
#301 

If the open generic type is registered, the closed generic type will be dynamically assembled at resolve time.

```csharp
builder.Register(typeof(IFoo<,>), typeof(Foo<,>))
```

📝  Usage:
https://github.com/Cysharp/MessagePipe/blob/master/src/MessagePipe/ServiceCollectionExtensions.cs#L43-L102