### PR TITLE
Support asmdef Root Namespace option

### DIFF
--- a/VContainer/Assets/VContainer/Editor/ScriptTemplateModifier.cs
+++ b/VContainer/Assets/VContainer/Editor/ScriptTemplateModifier.cs
@@ -33,18 +33,21 @@ namespace VContainer.Editor
                 return;
             }
 
+            if (!scriptPath.EndsWith("LifetimeScope.cs"))
+            {
+                return;
+            }
+
+            var content = MonoInstallerTemplate.Replace("#SCRIPTNAME#", basename);
+
             if (scriptPath.StartsWith("Assets/"))
             {
                 scriptPath = scriptPath.Substring("Assets/".Length);
             }
 
             var fullPath = Path.Combine(Application.dataPath, scriptPath);
-            if (scriptPath.EndsWith("LifetimeScope.cs"))
-            {
-                var content = MonoInstallerTemplate.Replace("#SCRIPTNAME#", basename);
-                File.WriteAllText(fullPath, content);
-                AssetDatabase.Refresh();
-            }
+            File.WriteAllText(fullPath, content);
+            AssetDatabase.Refresh();
         }
     }
 }


### PR DESCRIPTION
Unity 2020.2よりアセンブリ定義ファイルに `Root Namespace` オプションと、それに対応する `#ROOTNAMESPACEBEGIN#` / `#ROOTNAMESPACEEND#` というスクリプトテンプレート向けのキーワードが追加されており、`LifetimeScope` のテンプレートコードでも対応できたらと思いPRを作成させていただきました。

```cs
    #ROOTNAMESPACEBEGIN#
class X
{
}
#ROOTNAMESPACEEND#
```

👇 

```cs
namespace <Root Namespaceで設定した文字列>
{
    // #ROOTNAMESPACEBEGIN# の前に入れた空白分インデントされる
    class X
    {
    }
}
```

[`internal` な Unity API](https://github.com/Unity-Technologies/UnityCsReference/blob/2020.2/Editor/Mono/ProjectWindow/ProjectWindowUtil.cs#L495-L550) が必要なためリフレクションを使用しておりますが、こちらが問題になりそうであれば [このコミット](https://github.com/hadashiA/VContainer/commit/d4b5dbf8a912cd54e3587c97288a55f998419bd7) だけでも取り入れていただければと思います :bow: （先にやる必要のない文字列処理を後で行うように変更いたしました）

※リフレクションを避けるためにスクリプトテンプレートをどこかに配置して [`ProjectWindowUtil. CreateScriptAssetFromTemplateFile`](https://github.com/Unity-Technologies/UnityCsReference/blob/2020.2/Editor/Mono/ProjectWindow/ProjectWindowUtil.cs#L348) を使うような形も検討しましたが、余計なファイルが増えてしまうため現在の形で対応いたしました。