### PR TITLE
Optimize foreach performance

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/IObjectResolverExtensions.cs
+++ b/VContainer/Assets/VContainer/Runtime/IObjectResolverExtensions.cs
@@ -19,8 +19,10 @@ namespace VContainer
         {
             if (parameters != null)
             {
-                foreach (var parameter in parameters)
+                // ReSharper disable once ForCanBeConvertedToForeach
+                for (var i = 0; i < parameters.Count; i++)
                 {
+                    var parameter = parameters[i];
                     if (parameter.Match(parameterType, parameterName))
                     {
                         return parameter.Value;

--- a/VContainer/Assets/VContainer/Runtime/Internal/FixedTypeKeyHashTableRegistry.cs
+++ b/VContainer/Assets/VContainer/Runtime/Internal/FixedTypeKeyHashTableRegistry.cs
@@ -20,11 +20,12 @@ namespace VContainer.Internal
 
             foreach (var registration in registrations)
             {
-                if (registration.InterfaceTypes?.Count > 0)
+                if (registration.InterfaceTypes is IReadOnlyList<Type> interfaceTypes)
                 {
-                    foreach (var interfaceType in registration.InterfaceTypes)
+                    // ReSharper disable once ForCanBeConvertedToForeach
+                    for (var i = 0; i < interfaceTypes.Count; i++)
                     {
-                        AddToBuildBuffer(buildBuffer, interfaceType, registration);
+                        AddToBuildBuffer(buildBuffer, interfaceTypes[i], registration);
                     }
 
                     // Mark the ImplementationType with a guard because we need to check if it exists later.
@@ -71,8 +72,10 @@ namespace VContainer.Internal
 
         static void AddCollectionToBuildBuffer(IDictionary<Type, IRegistration> buf, CollectionRegistration collectionRegistration)
         {
-            foreach (var collectionType in collectionRegistration.InterfaceTypes)
+            // ReSharper disable once ForCanBeConvertedToForeach
+            for (var i = 0; i < collectionRegistration.InterfaceTypes.Count; i++)
             {
+                var collectionType = collectionRegistration.InterfaceTypes[i];
                 try
                 {
                     buf.Add(collectionType, collectionRegistration);


### PR DESCRIPTION
`Array<>` and `List<>` foreach will be expanded into allocation-free code at compile time. 
However, Interfaces such as `Ilist<>` and `IReadOnlyList<>` don't seem to do so.  It seems that allocations occur because they go through the IEnumerator.

I preferred `IReadOnlyList<>`, but found that changing foreach to a for statement reduced the allocation.

Refs:
https://levelup.gitconnected.com/ilist-t-vs-list-t-performance-dad1688a374f

## An example of container build test case

### Before

![screenshot-2021-06-19-124315](https://user-images.githubusercontent.com/727159/122630028-f32b4500-d0fb-11eb-9eca-acb9e50643b5.png)


### After

![screenshot-2021-06-19-123156](https://user-images.githubusercontent.com/727159/122629778-6e8bf700-d0fa-11eb-8fd3-aa88275a9ca8.png)
