### PR TITLE
Fix allocation on tickables

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/Unity/PlayerLoopItem.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/PlayerLoopItem.cs
@@ -186,7 +186,7 @@ namespace VContainer.Unity
 
     sealed class PostFixedTickableLoopItem : IPlayerLoopItem, IDisposable
     {
-        readonly IEnumerable<IPostFixedTickable> entries;
+        readonly List<IPostFixedTickable> entries;
         readonly EntryPointExceptionHandler exceptionHandler;
         bool disposed;
 
@@ -194,7 +194,7 @@ namespace VContainer.Unity
             IEnumerable<IPostFixedTickable> entries,
             EntryPointExceptionHandler exceptionHandler)
         {
-            this.entries = entries;
+            this.entries = entries.ToList();
             this.exceptionHandler = exceptionHandler;
         }
 
@@ -331,7 +331,7 @@ namespace VContainer.Unity
 
     sealed class PostLateTickableLoopItem : IPlayerLoopItem, IDisposable
     {
-        readonly IEnumerable<IPostLateTickable> entries;
+        readonly List<IPostLateTickable> entries;
         readonly EntryPointExceptionHandler exceptionHandler;
         bool disposed;
 
@@ -339,7 +339,7 @@ namespace VContainer.Unity
             IEnumerable<IPostLateTickable> entries,
             EntryPointExceptionHandler exceptionHandler)
         {
-            this.entries = entries;
+            this.entries = entries.ToList();
             this.exceptionHandler = exceptionHandler;
         }
 

--- a/VContainer/Assets/VContainer/Runtime/Unity/PlayerLoopItem.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/PlayerLoopItem.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 #if VCONTAINER_UNITASK_INTEGRATION
 using System.Threading;
 using Cysharp.Threading.Tasks;
@@ -221,7 +222,7 @@ namespace VContainer.Unity
 
     sealed class TickableLoopItem : IPlayerLoopItem, IDisposable
     {
-        readonly IEnumerable<ITickable> entries;
+        readonly List<ITickable> entries;
         readonly EntryPointExceptionHandler exceptionHandler;
         bool disposed;
 
@@ -229,7 +230,7 @@ namespace VContainer.Unity
             IEnumerable<ITickable> entries,
             EntryPointExceptionHandler exceptionHandler)
         {
-            this.entries = entries;
+            this.entries = entries.ToList();
             this.exceptionHandler = exceptionHandler;
         }
 
@@ -249,6 +250,7 @@ namespace VContainer.Unity
                     return false;
                 }
             }
+
             return !disposed;
         }
 

--- a/VContainer/Assets/VContainer/Runtime/Unity/PlayerLoopItem.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/PlayerLoopItem.cs
@@ -150,7 +150,7 @@ namespace VContainer.Unity
 
     sealed class FixedTickableLoopItem : IPlayerLoopItem, IDisposable
     {
-        readonly IEnumerable<IFixedTickable> entries;
+        readonly List<IFixedTickable> entries;
         readonly EntryPointExceptionHandler exceptionHandler;
         bool disposed;
 
@@ -158,7 +158,7 @@ namespace VContainer.Unity
             IEnumerable<IFixedTickable> entries,
             EntryPointExceptionHandler exceptionHandler)
         {
-            this.entries = entries;
+            this.entries = entries.ToList();
             this.exceptionHandler = exceptionHandler;
         }
 
@@ -259,7 +259,7 @@ namespace VContainer.Unity
 
     sealed class PostTickableLoopItem : IPlayerLoopItem, IDisposable
     {
-        readonly IEnumerable<IPostTickable> entries;
+        readonly List<IPostTickable> entries;
         readonly EntryPointExceptionHandler exceptionHandler;
         bool disposed;
 
@@ -267,7 +267,7 @@ namespace VContainer.Unity
             IEnumerable<IPostTickable> entries,
             EntryPointExceptionHandler exceptionHandler)
         {
-            this.entries = entries;
+            this.entries = entries.ToList();
             this.exceptionHandler = exceptionHandler;
         }
 

--- a/VContainer/Assets/VContainer/Runtime/Unity/PlayerLoopItem.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/PlayerLoopItem.cs
@@ -167,10 +167,9 @@ namespace VContainer.Unity
             if (disposed) return false;
             for (var i = 0; i < entries.Count; i++)
             {
-                var x = entries[i];
                 try
                 {
-                    x.FixedTick();
+                    entries[i].FixedTick();
                 }
                 catch (Exception ex)
                 {
@@ -204,10 +203,9 @@ namespace VContainer.Unity
             if (disposed) return false;
             for (var i = 0; i < entries.Count; i++)
             {
-                var x = entries[i];
                 try
                 {
-                    x.PostFixedTick();
+                    entries[i].PostFixedTick();
                 }
                 catch (Exception ex)
                 {
@@ -241,10 +239,9 @@ namespace VContainer.Unity
             if (disposed) return false;
             for (var i = 0; i < entries.Count; i++)
             {
-                var x = entries[i];
                 try
                 {
-                    x.Tick();
+                    entries[i].Tick();
                 }
                 catch (Exception ex)
                 {
@@ -278,10 +275,9 @@ namespace VContainer.Unity
             if (disposed) return false;
             for (var i = 0; i < entries.Count; i++)
             {
-                var x = entries[i];
                 try
                 {
-                    x.PostTick();
+                    entries[i].PostTick();
                 }
                 catch (Exception ex)
                 {
@@ -315,10 +311,9 @@ namespace VContainer.Unity
             if (disposed) return false;
             for (var i = 0; i < entries.Count; i++)
             {
-                var x = entries[i];
                 try
                 {
-                    x.LateTick();
+                    entries[i].LateTick();
                 }
                 catch (Exception ex)
                 {
@@ -352,10 +347,9 @@ namespace VContainer.Unity
             if (disposed) return false;
             for (var i = 0; i < entries.Count; i++)
             {
-                var x = entries[i];
                 try
                 {
-                    x.PostLateTick();
+                    entries[i].PostLateTick();
                 }
                 catch (Exception ex)
                 {

--- a/VContainer/Assets/VContainer/Runtime/Unity/PlayerLoopItem.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/PlayerLoopItem.cs
@@ -150,23 +150,24 @@ namespace VContainer.Unity
 
     sealed class FixedTickableLoopItem : IPlayerLoopItem, IDisposable
     {
-        readonly List<IFixedTickable> entries;
+        readonly IReadOnlyList<IFixedTickable> entries;
         readonly EntryPointExceptionHandler exceptionHandler;
         bool disposed;
 
         public FixedTickableLoopItem(
-            IEnumerable<IFixedTickable> entries,
+            IReadOnlyList<IFixedTickable> entries,
             EntryPointExceptionHandler exceptionHandler)
         {
-            this.entries = entries.ToList();
+            this.entries = entries;
             this.exceptionHandler = exceptionHandler;
         }
 
         public bool MoveNext()
         {
             if (disposed) return false;
-            foreach (var x in entries)
+            for (var i = 0; i < entries.Count; i++)
             {
+                var x = entries[i];
                 try
                 {
                     x.FixedTick();
@@ -186,23 +187,24 @@ namespace VContainer.Unity
 
     sealed class PostFixedTickableLoopItem : IPlayerLoopItem, IDisposable
     {
-        readonly List<IPostFixedTickable> entries;
+        readonly IReadOnlyList<IPostFixedTickable> entries;
         readonly EntryPointExceptionHandler exceptionHandler;
         bool disposed;
 
         public PostFixedTickableLoopItem(
-            IEnumerable<IPostFixedTickable> entries,
+            IReadOnlyList<IPostFixedTickable> entries,
             EntryPointExceptionHandler exceptionHandler)
         {
-            this.entries = entries.ToList();
+            this.entries = entries;
             this.exceptionHandler = exceptionHandler;
         }
 
         public bool MoveNext()
         {
             if (disposed) return false;
-            foreach (var x in entries)
+            for (var i = 0; i < entries.Count; i++)
             {
+                var x = entries[i];
                 try
                 {
                     x.PostFixedTick();
@@ -222,23 +224,24 @@ namespace VContainer.Unity
 
     sealed class TickableLoopItem : IPlayerLoopItem, IDisposable
     {
-        readonly List<ITickable> entries;
+        readonly IReadOnlyList<ITickable> entries;
         readonly EntryPointExceptionHandler exceptionHandler;
         bool disposed;
 
         public TickableLoopItem(
-            IEnumerable<ITickable> entries,
+            IReadOnlyList<ITickable> entries,
             EntryPointExceptionHandler exceptionHandler)
         {
-            this.entries = entries.ToList();
+            this.entries = entries;
             this.exceptionHandler = exceptionHandler;
         }
 
         public bool MoveNext()
         {
             if (disposed) return false;
-            foreach (var x in entries)
+            for (var i = 0; i < entries.Count; i++)
             {
+                var x = entries[i];
                 try
                 {
                     x.Tick();
@@ -258,23 +261,24 @@ namespace VContainer.Unity
 
     sealed class PostTickableLoopItem : IPlayerLoopItem, IDisposable
     {
-        readonly List<IPostTickable> entries;
+        readonly IReadOnlyList<IPostTickable> entries;
         readonly EntryPointExceptionHandler exceptionHandler;
         bool disposed;
 
         public PostTickableLoopItem(
-            IEnumerable<IPostTickable> entries,
+            IReadOnlyList<IPostTickable> entries,
             EntryPointExceptionHandler exceptionHandler)
         {
-            this.entries = entries.ToList();
+            this.entries = entries;
             this.exceptionHandler = exceptionHandler;
         }
 
         public bool MoveNext()
         {
             if (disposed) return false;
-            foreach (var x in entries)
+            for (var i = 0; i < entries.Count; i++)
             {
+                var x = entries[i];
                 try
                 {
                     x.PostTick();
@@ -294,12 +298,12 @@ namespace VContainer.Unity
 
     sealed class LateTickableLoopItem : IPlayerLoopItem, IDisposable
     {
-        readonly IEnumerable<ILateTickable> entries;
+        readonly IReadOnlyList<ILateTickable> entries;
         readonly EntryPointExceptionHandler exceptionHandler;
         bool disposed;
 
         public LateTickableLoopItem(
-            IEnumerable<ILateTickable> entries,
+            IReadOnlyList<ILateTickable> entries,
             EntryPointExceptionHandler exceptionHandler)
         {
             this.entries = entries;
@@ -309,8 +313,9 @@ namespace VContainer.Unity
         public bool MoveNext()
         {
             if (disposed) return false;
-            foreach (var x in entries)
+            for (var i = 0; i < entries.Count; i++)
             {
+                var x = entries[i];
                 try
                 {
                     x.LateTick();
@@ -330,23 +335,24 @@ namespace VContainer.Unity
 
     sealed class PostLateTickableLoopItem : IPlayerLoopItem, IDisposable
     {
-        readonly List<IPostLateTickable> entries;
+        readonly IReadOnlyList<IPostLateTickable> entries;
         readonly EntryPointExceptionHandler exceptionHandler;
         bool disposed;
 
         public PostLateTickableLoopItem(
-            IEnumerable<IPostLateTickable> entries,
+            IReadOnlyList<IPostLateTickable> entries,
             EntryPointExceptionHandler exceptionHandler)
         {
-            this.entries = entries.ToList();
+            this.entries = entries;
             this.exceptionHandler = exceptionHandler;
         }
 
         public bool MoveNext()
         {
             if (disposed) return false;
-            foreach (var x in entries)
+            for (var i = 0; i < entries.Count; i++)
             {
+                var x = entries[i];
                 try
                 {
                     x.PostLateTick();

--- a/VContainer/Assets/VContainer/Runtime/Unity/PlayerLoopItem.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/PlayerLoopItem.cs
@@ -250,7 +250,6 @@ namespace VContainer.Unity
                     return false;
                 }
             }
-
             return !disposed;
         }
 

--- a/VContainer/Assets/VContainer/Tests/Unity/PlayerLoopItemTest.cs
+++ b/VContainer/Assets/VContainer/Tests/Unity/PlayerLoopItemTest.cs
@@ -8,11 +8,13 @@ namespace VContainer.Tests.Unity
 {
     public class PlayerLoopItemTest
     {
-        private class Ticker : ITickable, IPostTickable, IFixedTickable
+        private class Ticker : ITickable, IPostTickable, IPostLateTickable, IFixedTickable, IPostFixedTickable
         {
             public void Tick() { }
             public void FixedTick() { }
             public void PostTick() { }
+            public void PostLateTick() { }
+            public void PostFixedTick() { }
         }
 
         private class TickableLoopItemTest
@@ -47,6 +49,22 @@ namespace VContainer.Tests.Unity
             }
         }
         
+        private class PostLateTickableLoopItemTest
+        {
+            [Test]
+            public void MoveNextWithoutAllocation()
+            {
+                var list = new List<IPostLateTickable> { new Ticker(), new Ticker() };
+                var exceptionHandler = new EntryPointExceptionHandler(exception => { });
+                var tickableLoopItem = new PostLateTickableLoopItem(list, exceptionHandler);
+                
+                Assert.That(() =>
+                {
+                    tickableLoopItem.MoveNext();
+                }, Is.Not.AllocatingGCMemory());
+            }
+        }
+        
         private class FixedTickableLoopItemTest
         {
             [Test]
@@ -55,6 +73,22 @@ namespace VContainer.Tests.Unity
                 var list = new List<IFixedTickable> { new Ticker(), new Ticker() };
                 var exceptionHandler = new EntryPointExceptionHandler(exception => { });
                 var tickableLoopItem = new FixedTickableLoopItem(list, exceptionHandler);
+                
+                Assert.That(() =>
+                {
+                    tickableLoopItem.MoveNext();
+                }, Is.Not.AllocatingGCMemory());
+            }
+        }
+        
+        private class PostFixedTickableLoopItemTest
+        {
+            [Test]
+            public void MoveNextWithoutAllocation()
+            {
+                var list = new List<IPostFixedTickable> { new Ticker(), new Ticker() };
+                var exceptionHandler = new EntryPointExceptionHandler(exception => { });
+                var tickableLoopItem = new PostFixedTickableLoopItem(list, exceptionHandler);
                 
                 Assert.That(() =>
                 {

--- a/VContainer/Assets/VContainer/Tests/Unity/PlayerLoopItemTest.cs
+++ b/VContainer/Assets/VContainer/Tests/Unity/PlayerLoopItemTest.cs
@@ -8,19 +8,53 @@ namespace VContainer.Tests.Unity
 {
     public class PlayerLoopItemTest
     {
-        internal class TickableLoopItemTest
+        private class Ticker : ITickable, IPostTickable, IFixedTickable
         {
-            private class Ticker : ITickable
-            {
-                public void Tick() { }
-            }
+            public void Tick() { }
+            public void FixedTick() { }
+            public void PostTick() { }
+        }
 
+        private class TickableLoopItemTest
+        {
             [Test]
             public void MoveNextWithoutAllocation()
             {
                 var list = new List<ITickable> { new Ticker(), new Ticker() };
                 var exceptionHandler = new EntryPointExceptionHandler(exception => { });
                 var tickableLoopItem = new TickableLoopItem(list, exceptionHandler);
+                
+                Assert.That(() =>
+                {
+                    tickableLoopItem.MoveNext();
+                }, Is.Not.AllocatingGCMemory());
+            }
+        }
+        
+        private class PostTickableLoopItemTest
+        {
+            [Test]
+            public void MoveNextWithoutAllocation()
+            {
+                var list = new List<IPostTickable> { new Ticker(), new Ticker() };
+                var exceptionHandler = new EntryPointExceptionHandler(exception => { });
+                var tickableLoopItem = new PostTickableLoopItem(list, exceptionHandler);
+                
+                Assert.That(() =>
+                {
+                    tickableLoopItem.MoveNext();
+                }, Is.Not.AllocatingGCMemory());
+            }
+        }
+        
+        private class FixedTickableLoopItemTest
+        {
+            [Test]
+            public void MoveNextWithoutAllocation()
+            {
+                var list = new List<IFixedTickable> { new Ticker(), new Ticker() };
+                var exceptionHandler = new EntryPointExceptionHandler(exception => { });
+                var tickableLoopItem = new FixedTickableLoopItem(list, exceptionHandler);
                 
                 Assert.That(() =>
                 {

--- a/VContainer/Assets/VContainer/Tests/Unity/PlayerLoopItemTest.cs
+++ b/VContainer/Assets/VContainer/Tests/Unity/PlayerLoopItemTest.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine.TestTools.Constraints;
+using VContainer.Unity;
+using Is = NUnit.Framework.Is;
+
+namespace VContainer.Tests.Unity
+{
+    public class PlayerLoopItemTest
+    {
+        internal class TickableLoopItemTest
+        {
+            private class Ticker : ITickable
+            {
+                public void Tick() { }
+            }
+
+            [Test]
+            public void MoveNextWithoutAllocation()
+            {
+                var list = new List<ITickable> { new Ticker(), new Ticker() };
+                var exceptionHandler = new EntryPointExceptionHandler(exception => { });
+                var tickableLoopItem = new TickableLoopItem(list, exceptionHandler);
+                
+                Assert.That(() =>
+                {
+                    tickableLoopItem.MoveNext();
+                }, Is.Not.AllocatingGCMemory());
+            }
+        }
+    }
+}

--- a/VContainer/Assets/VContainer/Tests/Unity/PlayerLoopItemTest.cs.meta
+++ b/VContainer/Assets/VContainer/Tests/Unity/PlayerLoopItemTest.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 78a772dee4fb4a8a9d55d1307959bfe7
+timeCreated: 1625903364


### PR DESCRIPTION
When using Tickable, GC Allocation of 40 bytes per frame was occurring. 
`IEnumerable<T>.GetEnumerator()` causes an implicit cast, I think.

To solve this problem, I modified the LoopItem to explicitly hold the List inside.

I'd like you to see if it looks OK. 🙏 