### PR TITLE
Make sure that Initialize is called immediately

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/Unity/EntryPointDispatcher.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/EntryPointDispatcher.cs
@@ -32,19 +32,35 @@ namespace VContainer.Unity
             }
 
             var initializables = container.Resolve<IReadOnlyList<IInitializable>>();
-            if (initializables.Count > 0)
+            for (var i = 0; i < initializables.Count; i++)
             {
-                var loopItem = new InitializationLoopItem(initializables, exceptionHandler);
-                disposable.Add(loopItem);
-                PlayerLoopHelper.Dispatch(PlayerLoopTiming.Initialization, loopItem);
+                try
+                {
+                    initializables[i].Initialize();
+                }
+                catch (Exception ex)
+                {
+                    if (exceptionHandler != null)
+                        exceptionHandler.Publish(ex);
+                    else
+                        UnityEngine.Debug.LogException(ex);
+                }
             }
 
             var postInitializables = container.Resolve<IReadOnlyList<IPostInitializable>>();
-            if (postInitializables.Count > 0)
+            for (var i = 0; i < postInitializables.Count; i++)
             {
-                var loopItem = new PostInitializationLoopItem(postInitializables, exceptionHandler);
-                disposable.Add(loopItem);
-                PlayerLoopHelper.Dispatch(PlayerLoopTiming.PostInitialization, loopItem);
+                try
+                {
+                    postInitializables[i].PostInitialize();
+                }
+                catch (Exception ex)
+                {
+                    if (exceptionHandler != null)
+                        exceptionHandler.Publish(ex);
+                    else
+                        UnityEngine.Debug.LogException(ex);
+                }
             }
 
             var startables = container.Resolve<IReadOnlyList<IStartable>>();
@@ -130,7 +146,7 @@ namespace VContainer.Unity
                 x.SortSystems();
             }
 #endif
-       }
+        }
 
         public void Dispose() => disposable.Dispose();
     }

--- a/VContainer/Assets/VContainer/Runtime/Unity/PlayerLoopItem.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/PlayerLoopItem.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 #if VCONTAINER_UNITASK_INTEGRATION
 using System.Threading;
 using Cysharp.Threading.Tasks;
@@ -8,76 +7,6 @@ using Cysharp.Threading.Tasks;
 
 namespace VContainer.Unity
 {
-    sealed class InitializationLoopItem : IPlayerLoopItem, IDisposable
-    {
-        readonly IEnumerable<IInitializable> entries;
-        readonly EntryPointExceptionHandler exceptionHandler;
-        bool disposed;
-
-        public InitializationLoopItem(
-            IEnumerable<IInitializable> entries,
-            EntryPointExceptionHandler exceptionHandler)
-        {
-            this.entries = entries;
-            this.exceptionHandler = exceptionHandler;
-        }
-
-        public bool MoveNext()
-        {
-            if (disposed) return false;
-            foreach (var x in entries)
-            {
-                try
-                {
-                    x.Initialize();
-                }
-                catch (Exception ex)
-                {
-                    if (exceptionHandler == null) throw;
-                    exceptionHandler.Publish(ex);
-                }
-            }
-            return false;
-        }
-
-        public void Dispose() => disposed = true;
-    }
-
-    sealed class PostInitializationLoopItem : IPlayerLoopItem, IDisposable
-    {
-        readonly IEnumerable<IPostInitializable> entries;
-        readonly EntryPointExceptionHandler exceptionHandler;
-        bool disposed;
-
-        public PostInitializationLoopItem(
-            IEnumerable<IPostInitializable> entries,
-            EntryPointExceptionHandler exceptionHandler)
-        {
-            this.entries = entries;
-            this.exceptionHandler = exceptionHandler;
-        }
-
-        public bool MoveNext()
-        {
-            if (disposed) return false;
-            foreach (var x in entries)
-            {
-                try
-                {
-                    x.PostInitialize();
-                }
-                catch (Exception ex)
-                {
-                    if (exceptionHandler == null) throw;
-                    exceptionHandler.Publish(ex);
-                }
-            }
-            return false;
-        }
-
-        public void Dispose() => disposed = true;
-    }
-
     sealed class StartableLoopItem : IPlayerLoopItem, IDisposable
     {
         readonly IEnumerable<IStartable> entries;

--- a/website/docs/integrations/entrypoint.mdx
+++ b/website/docs/integrations/entrypoint.mdx
@@ -32,8 +32,8 @@ Since it uses PlayerLoopSystem, it works even if you register at any time (e.g: 
 
 | VContaienr entry point                | Timing |
 |:--------------------------------------|:----------------------------------|
-| `IInitializable.Initialize()`         | Early `PlayerLoop.Initialization` |
-| `IPostInitializable.PostInitialize()` | Late `PlayerLoop.Initialization`  |
+| `IInitializable.Initialize()`         | Immediately after building the container |
+| `IPostInitializable.PostInitialize()` | Late `IInitializable.Initialize()`  |
 | `IStartable.Start()`                  | Nearly `MonoBehaviour.Start()`    |
 | `IPostStartable.PostStart()`          | After `MonoBehaviour.Start()`     |
 | `IFixedTickable.FixedTick()`          | Nearly `MonoBehaviour.FixedUpdate()` |

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/integrations/entrypoint.mdx
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/integrations/entrypoint.mdx
@@ -2,19 +2,15 @@
 title: Plain C# Entry point
 ---
 
-VContainerを使うと、素のC#オブジェクトをアプリケーションの処理の起点にすることができます。
 VContainer allows plain C# to be the starting point for application processing.
-
-これを `MonoBehaviour` の代わりに使用することで、制御フローのみをUnityの色々な機能とは分離することができます。
-
-以下は簡単な例です:
+Using it instead of MonoBehaviour, which has a lot of features, can help you build a simple control flow.
 
 ```csharp
 clas FooController : IStartable
 {
     void IStartable.Start()
     {
-        // イベント監視やルーチンなどを開始...
+        // Do something ...
     }
 }
 ```
@@ -23,9 +19,7 @@ clas FooController : IStartable
 builder.RegisterEntryPoint<FooController>();
 ```
 
-:::tip
 See [register](../registering/register-type#register-lifecycle-marker-interfaces)
-:::
 
 VContainer does this with its own PlayerLoopSystem.
 
@@ -38,8 +32,8 @@ Since it uses PlayerLoopSystem, it works even if you register at any time (e.g: 
 
 | VContaienr entry point                | Timing |
 |:--------------------------------------|:----------------------------------|
-| `IInitializable.Initialize()`         | Early `PlayerLoop.Initialization` |
-| `IPostInitializable.PostInitialize()` | Late `PlayerLoop.Initialization`  |
+| `IInitializable.Initialize()`         | Immediately after building the container |
+| `IPostInitializable.PostInitialize()` | Late `IInitializable.Initialize()`  |
 | `IStartable.Start()`                  | Nearly `MonoBehaviour.Start()`    |
 | `IPostStartable.PostStart()`          | After `MonoBehaviour.Start()`     |
 | `IFixedTickable.FixedTick()`          | Nearly `MonoBehaviour.FixedUpdate()` |


### PR DESCRIPTION
#266 

Problems:
1. If the scope is built at frame 0, `IInitializable` / `IStartable` / `ITickable` / etc  will wait until frame 1.
    - `MonoBehaviour.Start` is also the same, so I guess it can't be helped.
2. If the scope is built after the first frame, Start/Tick will be called in the same frame, but `Initialize` will wait until the next frame.
    - This is, perhaps, unexpected.

Here, to solve problem 2, `IInitializable` will not use PlayerLoop, but will be called immediately at built of scope.