### PR TITLE
Fix to dispatch entrypoint lifecycle for RootLifetimeScope

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/Unity/LifetimeScope.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/LifetimeScope.cs
@@ -130,7 +130,7 @@ namespace VContainer.Unity
                     Build();
                 }
             }
-            catch (VContainerParentTypeReferenceNotFound)
+            catch (VContainerParentTypeReferenceNotFound) when(!IsRoot)
             {
                 if (WaitingList.Contains(this))
                 {
@@ -151,6 +151,13 @@ namespace VContainer.Unity
         {
             DisposeCore();
             if (this != null) Destroy(gameObject);
+        }
+
+        public void DisposeCore()
+        {
+            Container?.Dispose();
+            Container = null;
+            CancelAwake(this);
         }
 
         public void Build()
@@ -265,9 +272,9 @@ namespace VContainer.Unity
                 return nextParent;
 
             // Find root from settings
-            if (VContainerSettings.Instance is VContainerSettings settings)
+            if (VContainerSettings.Instance != null)
             {
-                var rootLifetimeScope = settings.RootLifetimeScope;
+                var rootLifetimeScope = VContainerSettings.Instance.RootLifetimeScope;
                 if (rootLifetimeScope != null)
                 {
                     if (rootLifetimeScope.Container == null)
@@ -278,13 +285,6 @@ namespace VContainer.Unity
                 }
             }
             return null;
-        }
-
-        void DisposeCore()
-        {
-            Container?.Dispose();
-            Container = null;
-            CancelAwake(this);
         }
 
         void AutoInjectAll()

--- a/VContainer/Assets/VContainer/Runtime/Unity/VContainerSettings.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/VContainerSettings.cs
@@ -44,13 +44,30 @@ namespace VContainer.Unity
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
         static void RuntimeInitialize()
         {
+            // For editor, we need to load the Preload asset manually.
             LoadInstanceFromPreloadAssets();
         }
 
         [UnityEditor.InitializeOnLoadMethod]
         static void EditorInitialize()
         {
-            LoadInstanceFromPreloadAssets();
+            // RootLifetimeScope must be disposed before it can be resumed.
+            UnityEditor.EditorApplication.playModeStateChanged += state =>
+            {
+                switch (state)
+                {
+                    case UnityEditor.PlayModeStateChange.ExitingPlayMode:
+                        if (Instance != null)
+                        {
+                            if (Instance.RootLifetimeScope != null)
+                            {
+                                Instance.RootLifetimeScope.DisposeCore();
+                            }
+                            Instance = null;
+                        }
+                        break;
+                }
+            };
         }
 #endif
 


### PR DESCRIPTION
#284 

Problems:
- Once exit Play mode, the EntryPoint of the RootLifetimeScope will not be scheduled again.
- After exiting Play mode, the ITickable, etc. will remain on the Player Loop.
  -  This is because the RootLifetimeScope will not be disposed.

Check List:
- Domain Reloading Disabled:
    - [x] After launching Editor
    - [x] Enter play mode again
    - [x] After refreching Editor
- Domain Reloading Enabled:
    - [x] After launching Editor
    - [x] Enter play mode again
    - [x] After refreching Editor 