### PR TITLE
Add documentationUrl and licenceUrl to package.json

### DIFF
--- a/VContainer/Assets/VContainer/package.json
+++ b/VContainer/Assets/VContainer/package.json
@@ -7,6 +7,7 @@
   "keywords": ["DI", "Dependency Injection", "DI Container"],
   "license": "MIT",
   "documentationUrl": "https://vcontainer.hadashikick.jp/",
+  "changelogUrl": "https://github.com/hadashiA/VContainer/releases",
   "licensesUrl": "https://github.com/hadashiA/VContainer/blob/master/LICENSE",
   "dependencies": {
     "com.unity.nuget.mono-cecil": "1.10.1"

--- a/VContainer/Assets/VContainer/package.json
+++ b/VContainer/Assets/VContainer/package.json
@@ -6,6 +6,8 @@
   "description": "The extra fast DI (Dependency Injection) for Unity",
   "keywords": ["DI", "Dependency Injection", "DI Container"],
   "license": "MIT",
+  "documentationUrl": "https://vcontainer.hadashikick.jp/",
+  "licensesUrl": "https://github.com/hadashiA/VContainer/blob/master/LICENSE",
   "dependencies": {
     "com.unity.nuget.mono-cecil": "1.10.1"
   }


### PR DESCRIPTION
You will be able to open the documentation and license from the package manager.

1. Open Package Manager Window
2. Select VContainer
    - Click `View documentation`
    - Click `View changelog`
    - Click `View license`