### PR TITLE
Fix collection resolve on parent

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/Annotations/AnnotationUtility.cs
+++ b/VContainer/Assets/VContainer/Runtime/Annotations/AnnotationUtility.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace VContainer.Unity
+{
+    public static class AnnotationUtility
+    {
+        private static readonly List<Type> _list = new List<Type>
+        {
+#if VCONTAINER_UNITASK_INTEGRATION
+            typeof(IAsyncStartable),
+#endif
+            typeof(IInitializable),
+            typeof(IPostInitializable),
+            typeof(IStartable),
+            typeof(IPostStartable),
+            typeof(IFixedTickable),
+            typeof(IPostFixedTickable),
+            typeof(ITickable),
+            typeof(IPostTickable),
+            typeof(ILateTickable),
+            typeof(IPostLateTickable)
+        };
+
+        public static bool IsLifecycleAnnotation(Type type) => _list.Contains(type);
+    }
+}

--- a/VContainer/Assets/VContainer/Runtime/Annotations/AnnotationUtility.cs.meta
+++ b/VContainer/Assets/VContainer/Runtime/Annotations/AnnotationUtility.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 5560a5e303b247a7916cf7ea2743cc16
+timeCreated: 1632227189

--- a/VContainer/Assets/VContainer/Tests/Fixtures.cs
+++ b/VContainer/Assets/VContainer/Tests/Fixtures.cs
@@ -2,7 +2,7 @@
 
 namespace VContainer.Tests
 {
-    interface I1
+    public interface I1
     {
     }
 

--- a/VContainer/Assets/VContainer/Tests/ScopedContainerTest.cs
+++ b/VContainer/Assets/VContainer/Tests/ScopedContainerTest.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework;
 
 namespace VContainer.Tests
@@ -190,6 +192,51 @@ namespace VContainer.Tests
             var scopedService = childContainer.Resolve<ServiceB>();
             //Assert.That(singletonService, Is.InstanceOf<ServiceA>());
             Assert.That(scopedService, Is.InstanceOf<ServiceB>());
+        }
+        
+        [Test]
+        public void ResolveCollectionFromParent()
+        {
+            var builder = new ContainerBuilder();
+            builder.Register<I1, MultipleInterfaceServiceA>(Lifetime.Scoped);
+            builder.Register<I1, MultipleInterfaceServiceB>(Lifetime.Scoped);
+            var parentContainer = builder.Build();
+
+            var childContainer = parentContainer.CreateScope(childBuilder =>
+            {
+                childBuilder.Register<I1CollectionService>(Lifetime.Scoped);
+            });
+            
+            var scopedService = childContainer.Resolve<I1CollectionService>();
+            Assert.That(scopedService.enumerable.Count(), Is.EqualTo(2));
+        }
+        
+        [Test]
+        public void ResolveCollectionByLazyInstance()
+        {
+            var builder = new ContainerBuilder();
+            builder.Register<I1, MultipleInterfaceServiceA>(Lifetime.Scoped);
+            builder.Register<I1, MultipleInterfaceServiceB>(Lifetime.Scoped);
+            builder.Register<I1CollectionService>(Lifetime.Scoped);
+            
+            var parentContainer = builder.Build();
+
+            var childContainer = parentContainer.CreateScope(childBuilder =>
+            {
+            });
+            
+            var scopedService = childContainer.Resolve<I1CollectionService>();
+            Assert.That(scopedService.enumerable.Count(), Is.EqualTo(2));
+        }
+        
+        public class I1CollectionService
+        {
+            public readonly IReadOnlyList<I1> enumerable;
+
+            public I1CollectionService(IReadOnlyList<I1> enumerable)
+            {
+                this.enumerable = enumerable;
+            }
         }
 
         [Test]

--- a/website/docs/resolving/property-field-injection.mdx
+++ b/website/docs/resolving/property-field-injection.mdx
@@ -3,25 +3,21 @@ id: property-field-injection
 title: Property/Field Injection
 ---
 
-If the object has a local default and Inject is optional,
-Property/Field Injection can be used.
+Dependencies can be injected into properties or fields as well. To do so, annotate each property or field that represents a dependency with `[Inject]`.
 
 ```csharp
 class ClassA
 {
     [Inject]
-    IServiceA serviceA { get; set; } // Will be overwritten if something is registered.
+    IServiceA serviceA { get; set; }
+    
+    [Inject]
+    IServiceB serviceB;
 
     public ClassA()
     {
-        serviceA = ServiceA.GoodLocalDefault;
     }
 }
 ```
 
-It can resolve like this:
-
-```csharp
-    [Inject]
-    IServiceA serviceA;
-```
+Injection via properties or fields is a helpful alternative to [method injection](./method-injection).


### PR DESCRIPTION
refs #288 

- Fixed collection resolution to follow the parent container.
- Added validation so that only lifecycle interfaces such as IInitializable are not traced as exceptions

It works, but it's a little less beautiful, and I want you to see it.
