### PR TITLE
日本語版の About ページ内のリンクを修正

### DIFF
--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/about/what-is-vcontainer.mdx
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/about/what-is-vcontainer.mdx
@@ -252,6 +252,6 @@ builder.RegisterEntryPoint<FooController>();
 
 ## Getting Started
 
-- [Installation](/getting-started/installation)
+- [インストール](/getting-started/installation)
 - [Hello World](/getting-started/hello-world)
 - [Comparing to Zenject](/comparing/comparing-to-zenject)


### PR DESCRIPTION
日本語版の About ページ内の [Getting Started セクション](https://vcontainer.hadashikick.jp/ja/#getting-started)において以下のリンクのパスが壊れていたため、修正しました

- [Installation](https://vcontainer.hadashikick.jp/ja/getting-started/installation)
- [Hello World](https://vcontainer.hadashikick.jp/ja/getting-started/hello-world)
- [Comparing to Zenject](https://vcontainer.hadashikick.jp/ja/comparing/comparing-to-zenject)
<img width="348" alt="2021-10-10 17 53 49" src="https://user-images.githubusercontent.com/43922475/136689160-c38b34ff-ebca-410e-8a94-6878584e5d78.png">


ローカルで日本語版をビルドして、正しく動作することを確認済みです