### PR TITLE
PrefabComponentProvider.SpawnInstance will change the spawned prefab's active state on failed injection

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/Unity/InstanceProviders/PrefabComponentProvider.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/InstanceProviders/PrefabComponentProvider.cs
@@ -36,13 +36,19 @@ namespace VContainer.Unity
                 ? UnityEngine.Object.Instantiate(prefab, parent)
                 : UnityEngine.Object.Instantiate(prefab);
 
-            injector.Inject(component, resolver, customParameters);
-
-            if (wasActive)
+            try
             {
-                prefab.gameObject.SetActive(true);
-                component.gameObject.SetActive(true);
+                injector.Inject(component, resolver, customParameters);
             }
+            finally
+            {
+                if (wasActive)
+                {
+                    prefab.gameObject.SetActive(true);
+                    component.gameObject.SetActive(true);
+                }
+            }
+
             return component;
         }
     }

--- a/VContainer/Assets/VContainer/Tests/Unity/UnityContainerBuilderTest.cs
+++ b/VContainer/Assets/VContainer/Tests/Unity/UnityContainerBuilderTest.cs
@@ -347,6 +347,22 @@ namespace VContainer.Tests.Unity
         }
 
         [Test]
+        public void RegisterComponentInNewPrefabWithFailedResolve()
+        {
+            var prefab = new GameObject("Sample").AddComponent<SampleMonoBehaviour>();
+
+            var builder = new ContainerBuilder();
+            builder.RegisterComponentInNewPrefab(prefab, Lifetime.Singleton);
+
+            var container = builder.Build();
+            Assert.Catch(() =>
+            {
+                container.Resolve<SampleMonoBehaviour>();
+            });
+            Assert.That(prefab.gameObject.activeSelf, Is.True);
+        }
+
+        [Test]
         public void UseComponentsWithParentTransform()
         {
             var go1 = new GameObject("Parent");


### PR DESCRIPTION
A proposed solution for the issue described on https://github.com/hadashiA/VContainer/issues/330

`PrefabComponentProvider` will change the prefab's `active` state to inactive if there is a failure when injecting the spawned gameObject. This happens because `PrefabComponentProvider.SpawnInstance` changes the prefab to inactive before spawning it, and if `injector.Inject` throws an exception the function execution is halted, and the prefab's `active` state is left to inactive.

In order to prevent, we can add a try-finally block when calling `injector.Inject` function, and add re-activation of the prefab inside the `finally` block.

I have also added a unit-test for this case.