### PR TITLE
Fix syntax issue in site docs

### DIFF
--- a/website/docs/registering/register-scriptable-object.mdx
+++ b/website/docs/registering/register-scriptable-object.mdx
@@ -26,7 +26,7 @@ public class ActorSettings
 public class GameSettings : ScriptableObject
 {
     [SerializeField]
-    public CameraSettings cameraSetting
+    public CameraSettings cameraSetting;
 
     [SerializeField]
     public ActorSettings actorSettings;


### PR DESCRIPTION
A semicolon is missing at https://vcontainer.hadashikick.jp/registering/register-scriptable-object