### PR TITLE
Feature Suggestion: Detailed circular dependency exception message

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/Internal/TypeAnalyzer.cs
+++ b/VContainer/Assets/VContainer/Runtime/Internal/TypeAnalyzer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 
 namespace VContainer.Internal
@@ -82,6 +83,67 @@ namespace VContainer.Internal
         }
     }
 
+    readonly struct DependencyNode
+    {
+        readonly Registration registration;
+        readonly object method; // ctor or method
+        readonly object param; // param or field or prop
+
+        public DependencyNode(Registration registration, InjectConstructorInfo ctor, ParameterInfo param)
+        {
+            this.registration = registration;
+            this.method = ctor;
+            this.param = param;
+        }
+
+        public DependencyNode(Registration registration, InjectMethodInfo method, ParameterInfo param)
+        {
+            this.registration = registration;
+            this.method = method;
+            this.param = param;
+        }
+
+        public DependencyNode(Registration registration, FieldInfo field)
+        {
+            this.registration = registration;
+            this.method = null;
+            this.param = field;
+        }
+
+        public DependencyNode(Registration registration, PropertyInfo prop)
+        {
+            this.registration = registration;
+            this.method = null;
+            this.param = prop;
+        }
+
+        public override string ToString()
+        {
+            if (this.method is InjectConstructorInfo ctor)
+            {
+                var param = (ParameterInfo)this.param;
+                return $"{registration.ImplementationType.FullName}::.ctor({param.Name})";
+            }
+            else if (this.method is InjectMethodInfo method)
+            {
+                var param = (ParameterInfo)this.param;
+                return $"{registration.ImplementationType.FullName}::{method.MethodInfo.Name}({param.Name})";
+            }
+            else if (this.param is FieldInfo field)
+            {
+                return $"{registration.ImplementationType.FullName}::{field.Name}";
+            }
+            else if (this.param is PropertyInfo prop)
+            {
+                return $"{registration.ImplementationType.FullName}::{prop.Name}";
+            }
+            else
+            {
+                return "";
+            }
+        }
+    }
+
     static class TypeAnalyzer
     {
         public static InjectTypeInfo AnalyzeWithCache(Type type) => Cache.GetOrAdd(type, AnalyzeFunc);
@@ -89,7 +151,7 @@ namespace VContainer.Internal
         static readonly ConcurrentDictionary<Type, InjectTypeInfo> Cache = new ConcurrentDictionary<Type, InjectTypeInfo>();
 
         [ThreadStatic]
-        static Stack<Registration> circularDependencyChecker;
+        static Stack<(DependencyNode Node, Registration Registration)> circularDependencyChecker;
 
         static Func<Type, InjectTypeInfo> AnalyzeFunc = Analyze;
 
@@ -181,27 +243,32 @@ namespace VContainer.Internal
         {
             // ThreadStatic
             if (circularDependencyChecker == null)
-                circularDependencyChecker = new Stack<Registration>();
+                circularDependencyChecker = new Stack<(DependencyNode Node, Registration Registration)>();
 
             for (var i = 0; i < registrations.Count; i++)
             {
                 circularDependencyChecker.Clear();
-                CheckCircularDependencyRecursive(registrations[i], registry, circularDependencyChecker);
+                CheckCircularDependencyRecursive(default, registrations[i], registry, circularDependencyChecker);
             }
         }
 
-        static void CheckCircularDependencyRecursive(Registration registration, Registry registry, Stack<Registration> stack)
+        static void CheckCircularDependencyRecursive(DependencyNode node, Registration registration, Registry registry, Stack<(DependencyNode Node, Registration Registration)> stack)
         {
-            foreach (var x in stack)
+            foreach (var (x, i) in stack.Select((x, i) => (x, i)))
             {
-                if (registration.ImplementationType == x.ImplementationType)
+                if (registration.ImplementationType == x.Registration.ImplementationType)
                 {
+                    stack.Push((node, registration));
+                    string path = string.Join("\n",
+                        stack.Take(i + 1)
+                            .Reverse()
+                            .Select((x, i) => $"    [{i + 1}] {x.Node} --> {x.Registration.ImplementationType.FullName}"));
                     throw new VContainerException(registration.ImplementationType,
-                        $"Circular dependency detected! {registration}");
+                        $"Circular dependency detected!\n{path}");
                 }
             }
 
-            stack.Push(registration);
+            stack.Push((node, registration));
 
             if (Cache.TryGetValue(registration.ImplementationType, out var injectTypeInfo))
             {
@@ -211,7 +278,7 @@ namespace VContainer.Internal
                     {
                         if (registry.TryGet(x.ParameterType, out var parameterRegistration))
                         {
-                            CheckCircularDependencyRecursive(parameterRegistration, registry, stack);
+                            CheckCircularDependencyRecursive(new DependencyNode(registration, injectTypeInfo.InjectConstructor, x), parameterRegistration, registry, stack);
                         }
                     }
                 }
@@ -224,7 +291,7 @@ namespace VContainer.Internal
                         {
                             if (registry.TryGet(x.ParameterType, out var parameterRegistration))
                             {
-                                CheckCircularDependencyRecursive(parameterRegistration, registry, stack);
+                                CheckCircularDependencyRecursive(new DependencyNode(registration, methodInfo, x), parameterRegistration, registry, stack);
                             }
                         }
                     }
@@ -236,7 +303,7 @@ namespace VContainer.Internal
                     {
                         if (registry.TryGet(x.FieldType, out var fieldRegistration))
                         {
-                            CheckCircularDependencyRecursive(fieldRegistration, registry, stack);
+                            CheckCircularDependencyRecursive(new DependencyNode(registration, x),fieldRegistration, registry, stack);
                         }
                     }
                 }
@@ -247,7 +314,7 @@ namespace VContainer.Internal
                     {
                         if (registry.TryGet(x.PropertyType, out var propertyRegistration))
                         {
-                            CheckCircularDependencyRecursive(propertyRegistration, registry, stack);
+                            CheckCircularDependencyRecursive(new DependencyNode(registration, x), propertyRegistration, registry, stack);
                         }
                     }
                 }

--- a/VContainer/Assets/VContainer/Tests/ContainerTest.cs
+++ b/VContainer/Assets/VContainer/Tests/ContainerTest.cs
@@ -474,6 +474,31 @@ namespace VContainer.Tests
         }
 
         [Test]
+        public void CircularDependencyMsg()
+        {
+            var builder = new ContainerBuilder();
+            builder.Register<HasCircularDependencyMsg1>(Lifetime.Transient);
+            builder.Register<HasCircularDependencyMsg2>(Lifetime.Transient);
+            builder.Register<HasCircularDependencyMsg3>(Lifetime.Transient);
+            builder.Register<HasCircularDependencyMsg4>(Lifetime.Transient);
+
+            var injector = InjectorCache.GetOrBuild(typeof(HasCircularDependencyMsg1));
+
+            // Only reflection mode can detect circular dependency errors at runtime.
+            if (injector is ReflectionInjector)
+            {
+                var ex = Assert.Throws<VContainerException>(() => builder.Build());
+                string expected =
+                    "Circular dependency detected!\n" +
+                    "    [1] VContainer.Tests.HasCircularDependencyMsg1::.ctor(dependency2) --> VContainer.Tests.HasCircularDependencyMsg2\n" +
+                    "    [2] VContainer.Tests.HasCircularDependencyMsg2::Method(dependency3) --> VContainer.Tests.HasCircularDependencyMsg3\n" +
+                    "    [3] VContainer.Tests.HasCircularDependencyMsg3::Field --> VContainer.Tests.HasCircularDependencyMsg4\n" +
+                    "    [4] VContainer.Tests.HasCircularDependencyMsg4::Prop --> VContainer.Tests.HasCircularDependencyMsg1";
+                Assert.That(ex.Message, Is.EqualTo(expected));
+            }
+        }
+
+        [Test]
         public void Inject()
         {
             var builder = new ContainerBuilder();

--- a/VContainer/Assets/VContainer/Tests/Fixtures.cs
+++ b/VContainer/Assets/VContainer/Tests/Fixtures.cs
@@ -248,6 +248,41 @@ namespace VContainer.Tests
         }
     }
 
+    class HasCircularDependencyMsg1
+    {
+        public HasCircularDependencyMsg1(HasCircularDependencyMsg2 dependency2)
+        {
+            if (dependency2 == null)
+            {
+                throw new ArgumentException();
+            }
+        }
+    }
+
+    class HasCircularDependencyMsg2
+    {
+        [Inject]
+        public void Method(HasCircularDependencyMsg3 dependency3)
+        {
+            if (dependency3 == null)
+            {
+                throw new ArgumentException();
+            }
+        }
+    }
+
+    class HasCircularDependencyMsg3
+    {
+        [Inject]
+        public HasCircularDependencyMsg4 Field;
+    }
+
+    class HasCircularDependencyMsg4
+    {
+        [Inject]
+        public HasCircularDependencyMsg1 Prop { get; set; }
+    }
+
     class HasMethodInjection : I1
     {
         public I2 Service2;


### PR DESCRIPTION
When VContainer finds a circular dependency, it now displays the following exception message:

```
VContainer.VContainerException : Circular dependency detected! Registration HasCircularDependency1 ContractTypes=[] Transient VContainer.Internal.InstanceProvider
```

Sometimes it was very time consuming to find the problem with only this message.

Therefore, I propose a feature that allows VContainer to display detailed messages such as the following:

```
VContainer.VContainerException : Circular dependency detected!
    [1] VContainer.Tests.HasCircularDependencyMsg1::.ctor(dependency2) --> VContainer.Tests.HasCircularDependencyMsg2
    [2] VContainer.Tests.HasCircularDependencyMsg2::Method(dependency3) --> VContainer.Tests.HasCircularDependencyMsg3
    [3] VContainer.Tests.HasCircularDependencyMsg3::Field --> VContainer.Tests.HasCircularDependencyMsg4
    [4] VContainer.Tests.HasCircularDependencyMsg4::Prop --> VContainer.Tests.HasCircularDependencyMsg1
```