### PR TITLE
Make sure RootLifetimeScope is disposed even on the build

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/Unity/DisposeLoopItem.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/DisposeLoopItem.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace VContainer.Unity
+{
+    sealed class DisposeLoopItem : IPlayerLoopItem
+    {
+        readonly IDisposable disposable;
+
+        public DisposeLoopItem(IDisposable disposable)
+        {
+            this.disposable = disposable;
+        }
+
+        public bool MoveNext()
+        {
+            disposable.Dispose();
+            return false;
+        }
+    }
+}

--- a/VContainer/Assets/VContainer/Runtime/Unity/DisposeLoopItem.cs.meta
+++ b/VContainer/Assets/VContainer/Runtime/Unity/DisposeLoopItem.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 792f76fbc1dd409887297cdfe8aa3aa9
+timeCreated: 1653803074


### PR DESCRIPTION
refs #382 

What we want to solve:
- On the editor, RootLifeScope is disposed before child scopes.
- On the build, RootLifeScope's Dispose is not called.

Fix:
- I think the Application.quitting event could be used.
- This event probably works when the application is closed on the actual device.
- However, since the order is earlier than destroying scenes and OnDestroy, use Dispatch to PlayerLoopSystem together.