### PR TITLE
Fix a issue with root lifetimescope running even though not play mode

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/Unity/VContainerSettings.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/VContainerSettings.cs
@@ -63,21 +63,24 @@ namespace VContainer.Unity
             LoadInstanceFromPreloadAssets();
         }
 #endif
-        
+
         void OnEnable()
         {
-            if (RootLifetimeScope != null)
+            if (Application.isPlaying)
             {
-                RootLifetimeScope.IsRoot = true;
-                if (RootLifetimeScope.Container == null && RootLifetimeScope.autoRun)
+                if (RootLifetimeScope != null)
                 {
-                    RootLifetimeScope.Build();
+                    RootLifetimeScope.IsRoot = true;
+                    if (RootLifetimeScope.Container == null && RootLifetimeScope.autoRun)
+                    {
+                        RootLifetimeScope.Build();
+                    }
                 }
+
+                Instance = this;
+                Application.quitting -= OnApplicationQuit;
+                Application.quitting += OnApplicationQuit;
             }
-            Instance = this;
-            
-            Application.quitting -= OnApplicationQuit;
-            Application.quitting += OnApplicationQuit;
         }
 
         void OnApplicationQuit()
@@ -91,7 +94,7 @@ namespace VContainer.Unity
                     // However, the GameObject may be destroyed at that time.
                     PlayerLoopHelper.Dispatch(PlayerLoopTiming.LateUpdate, new AsyncLoopItem(() =>
                     {
-                        RootLifetimeScope.DisposeCore();                        
+                        RootLifetimeScope.DisposeCore();
                     }));
                 }
             }


### PR DESCRIPTION
Perhaps a Unity 2022.1 issue?

I noticed that VContainerSettings.OnEnable runs when the Editor Refresh completes.
I would like to add a check for isPlaying as a simple solution