### PR TITLE
Use old behaviour when root.autorun=false

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/Unity/LifetimeScope.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/LifetimeScope.cs
@@ -25,7 +25,7 @@ namespace VContainer.Unity
         public ParentReference parentReference;
 
         [SerializeField]
-        bool autoRun = true;
+        public bool autoRun = true;
 
         [SerializeField]
         protected List<GameObject> autoInjectGameObjects;

--- a/VContainer/Assets/VContainer/Runtime/Unity/VContainerSettings.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/VContainerSettings.cs
@@ -65,7 +65,7 @@ namespace VContainer.Unity
             if (RootLifetimeScope != null)
             {
                 RootLifetimeScope.IsRoot = true;
-                if (RootLifetimeScope.Container == null)
+                if (RootLifetimeScope.Container == null && RootLifetimeScope.autoRun)
                 {
                     RootLifetimeScope.Build();
                 }


### PR DESCRIPTION
Breaking change has been added [here](https://github.com/hadashiA/VContainer/commit/fc9a23ade980ab4fd3529f93d4a35a8752d8d5df#diff-da29166dce97a3572e4cdb6d6c29a087ab2f8796c2c1b8dff47d83ec43d96b59R68-R71).


Before breaking commit:
```
Scene.AutoRun=true:
  Awake
  Root.Configure
  Scene.Configure
  Awake end
Scene.AutoRun=false:
  Awake
  Root.Configure
  Awake end
```

After breaking commit:
```
Scene.AutoRun=true:
  Root.Configure
  Awake
  Scene.Configure
  Awake end
Scene.AutoRun=false:
  Root.Configure
  Awake
  Awake end
```

This PR reverts the old behaviour, when `Root.AutoRun=false` (Currently **Root.AutoRun** is not used)

I'd say that is more correctly and it requires to me:
I'm using async **LifetimeScopes** to preload **Addressables**, so I need to await **Awake** (via the first **SceneScope**, because **Awake** is not called on Prefab)

The public **autoRun** is useful for me too, currently I get these values via Reflection. 