### PR TITLE
fix: Exception thrown when InjectGameObject is reentered

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/Unity/ObjectResolverUnityExtensions.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/ObjectResolverUnityExtensions.cs
@@ -6,19 +6,20 @@ namespace VContainer.Unity
     {
         public static void InjectGameObject(this IObjectResolver resolver, GameObject gameObject)
         {
-            var buffer = UnityEngineObjectListBuffer<MonoBehaviour>.Get();
-
             void InjectGameObjectRecursive(GameObject current)
             {
                 if (current == null) return;
 
-                buffer.Clear();
-                current.GetComponents(buffer);
-                foreach (var monoBehaviour in buffer)
+                using (UnityEngineObjectListBuffer<MonoBehaviour>.Get(out var buffer))
                 {
-                    if (monoBehaviour != null)
-                    { // Can be null if the MonoBehaviour's type wasn't found (e.g. if it was stripped)
-                        resolver.Inject(monoBehaviour);
+                    buffer.Clear();
+                    current.GetComponents(buffer);
+                    foreach (var monoBehaviour in buffer)
+                    {
+                        if (monoBehaviour != null)
+                        { // Can be null if the MonoBehaviour's type wasn't found (e.g. if it was stripped)
+                            resolver.Inject(monoBehaviour);
+                        }
                     }
                 }
 

--- a/VContainer/Assets/VContainer/Runtime/Unity/UnityEngineObjectListBuffer.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/UnityEngineObjectListBuffer.cs
@@ -7,15 +7,60 @@ namespace VContainer.Unity
     {
         const int DefaultCapacity = 32;
 
-        [ThreadStatic]
-        static List<T> Instance = new List<T>(DefaultCapacity);
+        [ThreadStatic] 
+        private static Stack<List<T>> _pool = new Stack<List<T>>(4);
+        
+        /// <summary>
+        /// BufferScope supports releasing a buffer with using clause.
+        /// </summary>
+        public struct BufferScope : IDisposable
+        {
+            private readonly List<T> _buffer;
 
+            public BufferScope(List<T> buffer)
+            {
+                _buffer = buffer;
+            }
+            
+            public void Dispose()
+            {
+                Release(_buffer);
+            }
+        }
+
+        /// <summary>
+        /// Get a buffer from the pool.
+        /// </summary>
+        /// <returns></returns>
         public static List<T> Get()
         {
-            if (Instance == null)
-                Instance = new List<T>(DefaultCapacity);
-            Instance.Clear();
-            return Instance;
+            if (_pool.Count == 0)
+            {
+                return new List<T>(DefaultCapacity);
+            }
+
+            return _pool.Pop();
+        }
+
+        /// <summary>
+        /// Get a buffer from the pool. Returning a disposable struct to support recycling via using clause.
+        /// </summary>
+        /// <param name="buffer"></param>
+        /// <returns></returns>
+        public static BufferScope Get(out List<T> buffer)
+        {
+            buffer = Get();
+            return new BufferScope(buffer);
+        }
+
+        /// <summary>
+        /// Declare a buffer won't be used anymore and put it back to the pool.  
+        /// </summary>
+        /// <param name="buffer"></param>
+        public static void Release(List<T> buffer)
+        {
+            buffer.Clear();
+            _pool.Push(buffer);
         }
     }
 }

--- a/VContainer/Assets/VContainer/Tests/Unity/Fixtures/SampleMonoBehaviour3.cs
+++ b/VContainer/Assets/VContainer/Tests/Unity/Fixtures/SampleMonoBehaviour3.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using VContainer;
+using VContainer.Unity;
+
+namespace VContainer.Tests.Unity
+{
+    public class SampleMonoBehaviour3 : MonoBehaviour
+    {
+        public GameObject Prefab;
+        [Inject]
+        public void Construct(IObjectResolver container)
+        {
+            var go = Object.Instantiate(Prefab);
+            container.InjectGameObject(go);
+        }
+    }
+}

--- a/VContainer/Assets/VContainer/Tests/Unity/Fixtures/SampleMonoBehaviour3.cs.meta
+++ b/VContainer/Assets/VContainer/Tests/Unity/Fixtures/SampleMonoBehaviour3.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f96c27c4965064d5da0dccb8e5e76808
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VContainer/Assets/VContainer/Tests/Unity/UnityObjectResolverTest.cs
+++ b/VContainer/Assets/VContainer/Tests/Unity/UnityObjectResolverTest.cs
@@ -133,5 +133,23 @@ namespace VContainer.Tests.Unity
             Assert.That(instance3.transform.position, Is.EqualTo(new Vector3(1f, 2f, 3f)));
             Assert.That(instance3.transform.rotation, Is.EqualTo(Quaternion.Euler(1f, 2f, 3f)));
         }
+
+        [Test]
+        public void ReenterInjectGameObject()
+        {
+            var builder = new ContainerBuilder();
+            builder.Register<ServiceA>(Lifetime.Singleton);
+            var container = builder.Build();
+
+            var parent = new GameObject("Parent");
+            var original = new GameObject("Original");
+
+            var behaviour = original.AddComponent<SampleMonoBehaviour3>();
+            behaviour.Prefab = new GameObject("Nested");
+
+            var instance1 = container.Instantiate(original);
+            Assert.That(instance1, Is.Not.EqualTo(original));
+            Assert.That(instance1.GetComponent<SampleMonoBehaviour3>(), Is.InstanceOf<SampleMonoBehaviour3>());
+        }
     }
 }


### PR DESCRIPTION
## FIX
- `InvalidOperationException: Collection was modified; enumeration operation may not execute.` will be thrown when InjectGameObject is re-entered. Check the test case `ReenterInjectGameObject()` for details.
