### PR TITLE
Handle the case where a MonoBehaviour is null

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/Unity/ObjectResolverUnityExtensions.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/ObjectResolverUnityExtensions.cs
@@ -16,7 +16,10 @@ namespace VContainer.Unity
                 current.GetComponents(buffer);
                 foreach (var monoBehaviour in buffer)
                 {
-                    resolver.Inject(monoBehaviour);
+                    if (monoBehaviour != null)
+                    { // Can be null if the MonoBehaviour's type wasn't found (e.g. if it was stripped)
+                        resolver.Inject(monoBehaviour);
+                    }
                 }
 
                 var transform = current.transform;


### PR DESCRIPTION
The array or list returned by `GameObject.GetComponents` might have a `null` element if a `MonoBehaviour`'s type couldn't be found (e.g. if it was stripped). See [here](https://docs.unity3d.com/2022.1/Documentation/ScriptReference/GameObject.GetComponents.html) for details.