### PR TITLE
Fix: Instantiation of a MonoBehaviour doesn't inject the entire instantiated GameObject

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/Unity/ObjectResolverUnityExtensions.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/ObjectResolverUnityExtensions.cs
@@ -122,6 +122,12 @@ namespace VContainer.Unity
         {
             if (instance is GameObject gameObject)
                 resolver.InjectGameObject(gameObject);
+            else if( instance is Component component )
+                // if the prefab is instantiated with a component of a GameObject,
+                // (i.e. through the Instantiate<T>(T prefab) ),
+                // the newly instantiated GameObject which the returned component belongs to
+                // should also be injected.
+                resolver.InjectGameObject(component.gameObject);
             else
                 resolver.Inject(instance);
         }

--- a/VContainer/Assets/VContainer/Tests/Unity/UnityObjectResolverTest.cs
+++ b/VContainer/Assets/VContainer/Tests/Unity/UnityObjectResolverTest.cs
@@ -73,19 +73,25 @@ namespace VContainer.Tests.Unity
         {
             var builder = new ContainerBuilder();
             builder.Register<ServiceA>(Lifetime.Singleton);
+            builder.Register<ServiceB>(Lifetime.Singleton);
             var container = builder.Build();
 
             var parent = new GameObject("Parent");
             var original = new GameObject("Original").AddComponent<SampleMonoBehaviour>();
+            original.gameObject.AddComponent<SampleMonoBehaviour2>();
 
             var instance1 = container.Instantiate(original);
             Assert.That(instance1, Is.Not.EqualTo(original));
             Assert.That(instance1.ServiceA, Is.InstanceOf<ServiceA>());
+            Assert.That(instance1.GetComponent<SampleMonoBehaviour2>().ServiceB, Is.InstanceOf<ServiceB>());
+
 
             var instance2 = container.Instantiate(original, parent.transform);
             Assert.That(parent.GetComponentInChildren<SampleMonoBehaviour>(), Is.EqualTo(instance2));
             Assert.That(instance2, Is.Not.EqualTo(original));
             Assert.That(instance2.ServiceA, Is.InstanceOf<ServiceA>());
+            Assert.That(instance2.GetComponent<SampleMonoBehaviour2>().ServiceB, Is.InstanceOf<ServiceB>());
+
 
             var instance3 = container.Instantiate(
                 original,
@@ -94,6 +100,7 @@ namespace VContainer.Tests.Unity
 
             Assert.That(instance3, Is.Not.EqualTo(original));
             Assert.That(instance3.ServiceA, Is.InstanceOf<ServiceA>());
+            Assert.That(instance3.GetComponent<SampleMonoBehaviour2>().ServiceB, Is.InstanceOf<ServiceB>());
             Assert.That(instance3.transform.position, Is.EqualTo(new Vector3(1f, 2f, 3f)));
             Assert.That(instance3.transform.rotation, Is.EqualTo(Quaternion.Euler(1f, 2f, 3f)));
         }


### PR DESCRIPTION
When we pass a component to the `Object.Instantiate`, the Unity actually instantiates the entire GameObject that the MonoBehaviour belongs to. The returned MonoBehaviour instance actually attaches to a newly spawned GameObject which requires injection (initialization) also.

This patch fixes the issue that `T Instantiate(IObjectResolver resolver, T prefab ...)` series functions don't inject the entire spawned GameObject if a non-GameObject T is provided.

