### PR TITLE
Make ParentReference initializable

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/Unity/ParentReference.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/ParentReference.cs
@@ -14,12 +14,8 @@ namespace VContainer.Unity
 
         public Type Type { get; private set; }
 
-        public ParentReference(Type type)
+        ParentReference(Type type)
         {
-            if (!typeof(LifetimeScope).IsAssignableFrom(type))
-            {
-                throw new ArgumentException($"{type} does not inherit {nameof(LifetimeScope)}. Be sure to inherit from it.");
-            }
             Type = type;
             TypeName = type.FullName;
             Object = null;

--- a/VContainer/Assets/VContainer/Runtime/Unity/ParentReference.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/ParentReference.cs
@@ -14,6 +14,17 @@ namespace VContainer.Unity
 
         public Type Type { get; private set; }
 
+        public ParentReference(Type type)
+        {
+            if (!typeof(LifetimeScope).IsAssignableFrom(type))
+            {
+                throw new ArgumentException($"{type} does not inherit {nameof(LifetimeScope)}. Be sure to inherit from it.");
+            }
+            Type = type;
+            TypeName = type.FullName;
+            Object = null;
+        }
+
         void ISerializationCallbackReceiver.OnBeforeSerialize()
         {
             TypeName = Type?.FullName;
@@ -30,6 +41,11 @@ namespace VContainer.Unity
                         break;
                 }
             }
+        }
+
+        public static ParentReference Create<T>() where T : LifetimeScope
+        {
+            return new ParentReference(typeof(T));
         }
     }
 }


### PR DESCRIPTION
This change sets the initial value for `LifetimeScope.parentReference` and is useful when [Project root LifetimeScope](https://vcontainer.hadashikick.jp/ja/scoping/project-root-lifetimescope) is not available. By calling in Reset(), it is automatically set when the script is attached.

```C#
using VContainer.Unity;

public sealed class GameSceneLifetimeScope : LifetimeScope
{
    void Reset() => parentReference = ParentReference.Create<AppLifetimeScope>();
}
```