### PR TITLE
Remove itself from Inspector's Parent

### DIFF
--- a/VContainer/Assets/VContainer/Editor/ParentReferencePropertyDrawer.cs
+++ b/VContainer/Assets/VContainer/Editor/ParentReferencePropertyDrawer.cs
@@ -27,6 +27,11 @@ namespace VContainer.Editor
             if (names == null)
             {
                 names = GetAllTypeNames();
+                if (prop.serializedObject.targetObject is LifetimeScope lifetimeScope)
+                {
+                    var lifetimeScopeName = lifetimeScope.GetType().FullName;
+                    names = names.Where(name => name != lifetimeScopeName).ToArray();
+                }
             }
 
             var typeNameProp = prop.FindPropertyRelative("TypeName");


### PR DESCRIPTION
Added implementation to exclude own reference from `ParentReference` in `LifetimeScope`. Please consider this if you would like to do so.

![screenshot](https://user-images.githubusercontent.com/49128115/205889043-e417b8b5-f0b3-4908-8d4e-5f17448d7b81.png)