### PR TITLE
Better LifetimeScope.EnqueueParent

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/Unity/LifetimeScope.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/LifetimeScope.cs
@@ -11,8 +11,20 @@ namespace VContainer.Unity
     {
         public readonly struct ParentOverrideScope : IDisposable
         {
-            public ParentOverrideScope(LifetimeScope nextParent) => overrideParent = nextParent;
-            public void Dispose() => overrideParent = null;
+            readonly LifetimeScope parent;
+            
+            public ParentOverrideScope(LifetimeScope nextParent)
+            {
+                parent = nextParent;
+                overrideParent = nextParent;
+            }
+            
+            public void Dispose()
+            {
+                //don't remove in case it was overwritten
+                if(overrideParent == parent) 
+                    overrideParent = null;
+            }
         }
 
         public readonly struct ExtraInstallationScope : IDisposable


### PR DESCRIPTION
When using LifetimeScope.EnqueueParent a lot, it sometimes incorrectly removes the parent.

Code that fails without this fix:
```
using(LifetimeScope.EnqueueParent(parentScope))
{
	await Addressables.LoadSceneAsync(sceneRef);
       // another scene starts its own using(LifetimeScope.EnqueueParent(otherScope)) {
} // Dispose here removes parent set by other scene
```