### PR TITLE
Draft: Automatic addition all registered classes to link.xml

### DIFF
--- a/VContainer/Assets/VContainer/Editor/LinkGenerator.meta
+++ b/VContainer/Assets/VContainer/Editor/LinkGenerator.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7dd4e2ab029cc2f469d42fbe5bff6951
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VContainer/Assets/VContainer/Editor/LinkGenerator/AssemblyInfo.cs
+++ b/VContainer/Assets/VContainer/Editor/LinkGenerator/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("VContainer.Tests")]

--- a/VContainer/Assets/VContainer/Editor/LinkGenerator/AssemblyInfo.cs.meta
+++ b/VContainer/Assets/VContainer/Editor/LinkGenerator/AssemblyInfo.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: fd6b72cb6da74c0c8361180077b986b6
+timeCreated: 1679949022

--- a/VContainer/Assets/VContainer/Editor/LinkGenerator/LinkGeneratorTypeHelper.cs
+++ b/VContainer/Assets/VContainer/Editor/LinkGenerator/LinkGeneratorTypeHelper.cs
@@ -1,0 +1,145 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Xml;
+using UnityEngine;
+using VContainer.Internal;
+using VContainer.Unity;
+using Object = UnityEngine.Object;
+
+namespace VContainer.Editor.LinkGenerator
+{
+    internal class LinkGeneratorTypeHelper
+    {
+        public static void Generate(StreamWriter stream, List<Assembly> assemblies)
+        {
+            var membersToPreserve = GetTypesFromLifetimeScopesInAsseblies(assemblies);
+
+            if (membersToPreserve == null)
+                return;
+
+            var xmlBuilder = new VContainerXmlLinkBuilder();
+
+            foreach (InjectTypeInfo injectTypeInfo in membersToPreserve.Select(TypeAnalyzer.Analyze))
+                xmlBuilder.Add(injectTypeInfo);
+
+            xmlBuilder.WriteTo(XmlWriter.Create(stream, new XmlWriterSettings { Encoding = Encoding.UTF8, Indent = true }));
+        }
+
+        static List<Type> GetTypesFromLifetimeScopesInAsseblies(List<Assembly> assemblies)
+        {
+            var scopesContainer = new GameObject("[DELETE ME] VContainer.LinkGenerator");
+            var scopeInstances = new List<LifetimeScope>();
+            var scriptableInstances = new List<ScriptableObject>();
+            var typesToPreserve = new List<Type>();
+
+            try {
+                scopeInstances.AddRange(assemblies
+                    .SelectMany(assembly => assembly.DefinedTypes)
+                    .Where(myType => myType.IsClass && !myType.IsAbstract && myType.IsSubclassOf(typeof(LifetimeScope)))
+                    .Select(type => (LifetimeScope)scopesContainer.AddComponent(type)));
+
+                var builder = new ContainerBuilder();
+
+                for (var scopeIdx = 0; scopeIdx < scopeInstances.Count; scopeIdx++) {
+                    LifetimeScope scope = scopeInstances[scopeIdx];
+                    TypeInfo scopeTypeInfo = scope.GetType().GetTypeInfo();
+
+                    MethodInfo configureMethod = scopeTypeInfo.GetDeclaredMethod("Configure");
+
+                    if (configureMethod == null) {
+                        Debug.LogWarning(
+                            $"[{nameof(LinkGeneratorTypeHelper)}] couldn't generate link.xml for class {scope.GetType().FullName}," +
+                            " because we couldn't find method 'Configure'");
+                        continue;
+                    }
+
+                    // TODO: recursive field check
+                    // TODO: serialize reference support
+                    // TODO: recursive initialization. Sometimes user can bind field in serializable class
+                    foreach (FieldInfo field in scopeTypeInfo.DeclaredFields) {
+                        if (field.GetValue(scope) != null)
+                            continue;
+
+                        Type fieldType = field.FieldType.GetTypeInfo();
+
+                        if (fieldType.IsAbstract || fieldType.IsInterface || fieldType.IsGenericType)
+                            continue;
+
+                        if (fieldType.IsSubclassOf(typeof(Component))) {
+                            field.SetValue(scope, scopesContainer.AddComponent(fieldType));
+                            continue;
+                        }
+
+                        if (fieldType.IsSubclassOf(typeof(ScriptableObject))) {
+                            var instance = ScriptableObject.CreateInstance(fieldType);
+                            scriptableInstances.Add(instance);
+                            field.SetValue(scope, instance);
+                            continue;
+                        }
+
+                        object fValue = Activator.CreateInstance(fieldType);
+                        field.SetValue(scope, fValue);
+                    }
+
+                    // TODO: skip full class adding if is error
+                    UniversalResult invokeResult = configureMethod.SafeInvoke(scope, new object[] { builder });
+
+                    if (!invokeResult.IsSuccess) {
+                        Debug.LogWarning(
+                            $"[{nameof(LinkGeneratorTypeHelper)}] couldn't generate link.xml for class {scope.GetType().FullName}," +
+                            $" please add dependencies to preserve manually. Exception: {invokeResult.Ex}");
+                    }
+                }
+
+                for (int typeIdx = 0; typeIdx < builder.Count; typeIdx++)
+                    typesToPreserve.Add(builder.registrationBuilders[typeIdx].ImplementationType);
+            }
+            catch (Exception e) {
+                Debug.LogError($"FATAL ERROR: link.xml generation failed with message: {e}");
+                return null;
+            }
+            finally {
+                Object.DestroyImmediate(scopesContainer);
+
+                foreach (ScriptableObject o in scriptableInstances)
+                    Object.DestroyImmediate(o);
+            }
+
+            return typesToPreserve;
+        }
+    }
+
+    internal static class ReflectionExtension
+    {
+        public static UniversalResult SafeInvoke(this MethodInfo methodInfo, object instance, object[] @params)
+        {
+            try {
+                methodInfo.Invoke(instance, @params);
+            }
+            catch (Exception e) {
+                return UniversalResult.Failure(e);
+            }
+            return UniversalResult.Success();
+        }
+    }
+
+    // TODO make it generic and return for the whole class
+    internal readonly ref struct UniversalResult
+    {
+        public readonly bool IsSuccess;
+        public readonly Exception Ex;
+
+        private UniversalResult(bool isSuccess, Exception ex)
+        {
+            IsSuccess = isSuccess;
+            Ex = ex;
+        }
+
+        public static UniversalResult Success() => new(true, null);
+        public static UniversalResult Failure(Exception ex) => new(false, ex);
+    }
+}

--- a/VContainer/Assets/VContainer/Editor/LinkGenerator/LinkGeneratorTypeHelper.cs.meta
+++ b/VContainer/Assets/VContainer/Editor/LinkGenerator/LinkGeneratorTypeHelper.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 482e9f224af44b3486b83bc1bc5511f6
+timeCreated: 1679526239

--- a/VContainer/Assets/VContainer/Editor/LinkGenerator/VContainer.LinkGenerator.asmdef
+++ b/VContainer/Assets/VContainer/Editor/LinkGenerator/VContainer.LinkGenerator.asmdef
@@ -1,0 +1,18 @@
+{
+    "name": "VContainer.LinkGenerator",
+    "rootNamespace": "",
+    "references": [
+        "VContainer"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/VContainer/Assets/VContainer/Editor/LinkGenerator/VContainer.LinkGenerator.asmdef.meta
+++ b/VContainer/Assets/VContainer/Editor/LinkGenerator/VContainer.LinkGenerator.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 16cbf97e2d8f4d345b4ba46fcff82cd3
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VContainer/Assets/VContainer/Editor/LinkGenerator/VContainerLinkerProcessor.cs
+++ b/VContainer/Assets/VContainer/Editor/LinkGenerator/VContainerLinkerProcessor.cs
@@ -1,0 +1,65 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using UnityEditor.Build;
+using UnityEditor.Build.Reporting;
+using UnityEditor.Compilation;
+using UnityEditor.UnityLinker;
+
+namespace VContainer.Editor.LinkGenerator
+{
+    /*
+     * TODO
+     * Define the way to write tests
+     * Cover all parts by tests
+     * Finish all todos
+     * Don't forget that InjectTypeInfo.Type has changed
+     */
+    internal sealed class VContainerLinkerProcessor : IUnityLinkerProcessor, IPostprocessBuildWithReport
+    {
+        public static readonly string LinkXmlDirectoryPath = Path.Combine("Assets", "VContainer.LinkGenerator");
+        public static readonly string LinkXmlFilePath = Path.Combine(LinkXmlDirectoryPath, "link.xml");
+        public int callbackOrder { get; }
+
+        public string GenerateAdditionalLinkXmlFile(BuildReport report, UnityLinkerBuildPipelineData data)
+        {
+            UnityEditor.Compilation.Assembly[] unityAssemblies = CompilationPipeline.GetAssemblies(
+#if UNITY_2017_4_OR_NEWER
+                AssembliesType.PlayerWithoutTestAssemblies
+#endif
+            );
+
+            var toProcess = new List<System.Reflection.Assembly>();
+
+            foreach (UnityEditor.Compilation.Assembly unityAssembly in unityAssemblies) {
+                var dllReferences = unityAssembly.allReferences.Select(Path.GetFileNameWithoutExtension).ToList();
+
+                if (dllReferences.Any(x => x == "VContainer") &&
+                    dllReferences.Any(x => x == "VContainer.EnableLinkGenerator"))
+                    toProcess.Add(System.Reflection.Assembly.Load(new AssemblyName(unityAssembly.name)));
+            }
+
+            if (toProcess.Count == 0)
+                return null;
+
+            if (!Directory.Exists(LinkXmlDirectoryPath))
+                Directory.CreateDirectory(LinkXmlDirectoryPath);
+
+            // TODO if file empty unity linker will be crash
+            using (var stream = File.CreateText(LinkXmlFilePath)) {
+                LinkGeneratorTypeHelper.Generate(stream, toProcess);
+            }
+
+            return LinkXmlFilePath;
+        }
+
+        public void OnPostprocessBuild(BuildReport report)
+        {
+            // string fullPath = Path.Combine(Application.dataPath, "VContainer.LinkGenerator");
+            //
+            // if (Directory.Exists(fullPath))
+            //     Directory.Delete(fullPath, true);
+        }
+    }
+}

--- a/VContainer/Assets/VContainer/Editor/LinkGenerator/VContainerLinkerProcessor.cs.meta
+++ b/VContainer/Assets/VContainer/Editor/LinkGenerator/VContainerLinkerProcessor.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: d923b0f177cf4b6c8ec9ebf7a342fa3e
+timeCreated: 1679524384

--- a/VContainer/Assets/VContainer/Editor/LinkGenerator/VContainerXmlLinkBuilder.cs
+++ b/VContainer/Assets/VContainer/Editor/LinkGenerator/VContainerXmlLinkBuilder.cs
@@ -1,0 +1,151 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Xml;
+using VContainer.Internal;
+
+namespace VContainer.Editor.LinkGenerator
+{
+    internal sealed class VContainerXmlLinkBuilder
+    {
+        private readonly Dictionary<Assembly, List<InjectTypeInfo>> _map = new Dictionary<Assembly, List<InjectTypeInfo>>();
+        private readonly XmlDocument _doc;
+
+        public VContainerXmlLinkBuilder()
+        {
+            _doc = new XmlDocument();
+        }
+
+        public void Add(InjectTypeInfo info)
+        {
+            Assembly typeAssembly = info.Type.Assembly;
+
+            if (!_map.ContainsKey(typeAssembly))
+                _map.Add(typeAssembly, new List<InjectTypeInfo>());
+            else
+                _map[typeAssembly].Add(info);
+        }
+
+        public void WriteTo(XmlWriter writer)
+        {
+            var linkerNode = _doc.AppendChild(_doc.CreateElement("linker")); // <linker>
+
+            foreach (var k in _map.OrderBy(a => a.Key.FullName)) {
+                var assemblyNode = linkerNode.AppendChild(_doc.CreateElement("assembly")); // <assembly fullname="Assembly">
+                var assemblyAttr = _doc.CreateAttribute("fullname");
+                assemblyAttr.Value = k.Key.FullName;
+
+                if (assemblyNode.Attributes != null) {
+                    assemblyNode.Attributes.Append(assemblyAttr);
+
+                    foreach (var t in k.Value.OrderBy(t => t.Type.FullName)) {
+                        var typeNode = assemblyNode.AppendChild(_doc.CreateElement("type"));
+                        var typeAttr = _doc.CreateAttribute("fullname");
+                        typeAttr.Value = t.Type.FullName;
+                        typeNode.Attributes?.Append(typeAttr);
+
+                        if (t.InjectFields != null)
+                            AppendField(typeNode, t.InjectFields);
+
+                        if (t.InjectMethods != null)
+                            AppendMethod(typeNode, t.InjectMethods);
+
+                        if (t.InjectProperties != null)
+                            AppendProperty(typeNode, t.InjectProperties);
+
+                        if (t.InjectConstructor != null)
+                            AppendConstructor(typeNode, t.InjectConstructor);
+                    }
+                }
+            }
+            
+            _doc.Save(writer);
+        }
+
+        private void AppendField(XmlNode parentNode, IReadOnlyList<FieldInfo> fields)
+        {
+            // https://github.com/dotnet/linker/blob/main/docs/data-formats.md#preserve-only-selected-fields-on-a-type
+
+            foreach (FieldInfo f in fields) {
+                var fieldNode = parentNode.AppendChild(_doc.CreateElement("field"));
+                var signatureAttr = _doc.CreateAttribute("signature");
+                signatureAttr.Value = $"{f.FieldType.FullName} {f.Name}";
+                fieldNode.Attributes?.Append(signatureAttr);
+            }
+        }
+
+        private void AppendMethod(XmlNode parentNode, IReadOnlyList<InjectMethodInfo> methods)
+        {
+            // https://github.com/dotnet/linker/blob/main/docs/data-formats.md#preserve-only-selected-methods-on-a-type
+            var sb = new StringBuilder();
+
+            foreach (InjectMethodInfo m in methods) {
+                var methodNode = parentNode.AppendChild(_doc.CreateElement("method"));
+                var signatureAttr = _doc.CreateAttribute("signature");
+                AggregateMethodSignature(sb, m.MethodInfo.ReturnType.FullName, m.MethodInfo.Name, m.ParameterInfos);
+                signatureAttr.Value = sb.ToString();
+                sb.Clear();
+
+                methodNode.Attributes?.Append(signatureAttr);
+            }
+        }
+
+        private void AppendProperty(XmlNode parentNode, IReadOnlyList<PropertyInfo> props)
+        {
+            // https://github.com/dotnet/linker/blob/main/docs/data-formats.md#preserve-only-selected-properties-on-type
+            foreach (PropertyInfo p in props) {
+                var propNode = parentNode.AppendChild(_doc.CreateElement("property"));
+                var signatureAttr = _doc.CreateAttribute("signature");
+                signatureAttr.Value = $"{p.PropertyType.FullName} {p.Name}";
+                propNode.Attributes?.Append(signatureAttr);
+            }
+        }
+
+        private void AppendConstructor(XmlNode parentNode, InjectConstructorInfo ctor)
+        {
+            // there is no info about .ctor preserving, but it works as usual method
+            var sb = new StringBuilder();
+            var methodNode = parentNode.AppendChild(_doc.CreateElement("method"));
+            var signatureAttr = _doc.CreateAttribute("signature");
+            AggregateMethodSignature(sb, typeof(void).FullName, ".ctor", ctor.ParameterInfos);
+            signatureAttr.Value = sb.ToString();
+            sb.Clear();
+
+            methodNode.Attributes?.Append(signatureAttr);
+        }
+
+        private static void AggregateMethodSignature(StringBuilder sb,
+            string returnType,
+            string methodName,
+            ParameterInfo[] @params)
+        {
+            sb.Append(returnType);
+            sb.Append(' ');
+            sb.Append(methodName);
+            sb.Append('(');
+
+            if (@params.Length == 0)
+                sb.Append(')');
+            else if (@params.Length == 1) {
+                sb.Append(@params[0].ParameterType.FullName);
+                sb.Append(')');
+            }
+            else if (@params.Length > 1) {
+                for (var paramIdx = 0; paramIdx < @params.Length; paramIdx++) {
+                    var paramInfo = @params[paramIdx];
+
+                    if (paramIdx != @params.Length - 1) {
+                        sb.Append(paramInfo.ParameterType.FullName);
+                        sb.Append(", ");
+                    }
+                    else {
+                        sb.Append(paramInfo.ParameterType.FullName);
+                        sb.Append(')');
+                    }
+                }
+            }
+        }
+    }
+}

--- a/VContainer/Assets/VContainer/Editor/LinkGenerator/VContainerXmlLinkBuilder.cs.meta
+++ b/VContainer/Assets/VContainer/Editor/LinkGenerator/VContainerXmlLinkBuilder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: d4dc83b47d094e86b301df49fd45bd87
+timeCreated: 1679948047

--- a/VContainer/Assets/VContainer/Runtime/AssemblyInfo.cs
+++ b/VContainer/Assets/VContainer/Runtime/AssemblyInfo.cs
@@ -4,3 +4,4 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("VContainer.StandaloneTests")]
 [assembly: InternalsVisibleTo("VContainer.Editor")]
 [assembly: InternalsVisibleTo("Unity.VContainer.CodeGen")]
+[assembly: InternalsVisibleTo("VContainer.LinkGenerator")]

--- a/VContainer/Assets/VContainer/Runtime/ContainerBuilder.cs
+++ b/VContainer/Assets/VContainer/Runtime/ContainerBuilder.cs
@@ -68,7 +68,7 @@ namespace VContainer
             }
         }
 
-        readonly List<RegistrationBuilder> registrationBuilders = new List<RegistrationBuilder>();
+        internal readonly List<RegistrationBuilder> registrationBuilders = new List<RegistrationBuilder>();
         List<Action<IObjectResolver>> buildCallbacks;
         DiagnosticsCollector diagnostics;
 

--- a/VContainer/Assets/VContainer/Runtime/Internal/TypeAnalyzer.cs
+++ b/VContainer/Assets/VContainer/Runtime/Internal/TypeAnalyzer.cs
@@ -206,6 +206,7 @@ namespace VContainer.Internal
             var injectMethods = default(List<InjectMethodInfo>);
             var injectFields = default(List<FieldInfo>);
             var injectProperties = default(List<PropertyInfo>);
+            var startType = type;
             while (type != null && type != typeof(object))
             {
                 // Methods, [Inject] Only
@@ -245,7 +246,7 @@ namespace VContainer.Internal
             }
 
             return new InjectTypeInfo(
-                type,
+                startType,
                 injectConstructor,
                 injectMethods,
                 injectFields,

--- a/VContainer/Assets/VContainer/Runtime/LinkGenerator.meta
+++ b/VContainer/Assets/VContainer/Runtime/LinkGenerator.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a3a08de463d2f434db15f44ba131d41f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VContainer/Assets/VContainer/Runtime/LinkGenerator/Dummy.cs
+++ b/VContainer/Assets/VContainer/Runtime/LinkGenerator/Dummy.cs
@@ -1,0 +1,4 @@
+// This file marks empty asmdefs to prevent them from being deleted
+namespace VContainer.LinkGenerator
+{
+}

--- a/VContainer/Assets/VContainer/Runtime/LinkGenerator/Dummy.cs.meta
+++ b/VContainer/Assets/VContainer/Runtime/LinkGenerator/Dummy.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 20ab8857b45050541a273a9b464e110e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VContainer/Assets/VContainer/Runtime/LinkGenerator/VContainer.EnableLinkGenerator.asmdef
+++ b/VContainer/Assets/VContainer/Runtime/LinkGenerator/VContainer.EnableLinkGenerator.asmdef
@@ -1,0 +1,14 @@
+{
+  "name": "VContainer.EnableLinkGenerator",
+  "rootNamespace": "",
+  "references": [],
+  "includePlatforms": [],
+  "excludePlatforms": [],
+  "allowUnsafeCode": false,
+  "overrideReferences": false,
+  "precompiledReferences": [],
+  "autoReferenced": false,
+  "defineConstraints": [],
+  "versionDefines": [],
+  "noEngineReferences": true
+}

--- a/VContainer/Assets/VContainer/Runtime/LinkGenerator/VContainer.EnableLinkGenerator.asmdef.meta
+++ b/VContainer/Assets/VContainer/Runtime/LinkGenerator/VContainer.EnableLinkGenerator.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: fd1a7607dc013d24484a9cb09654e154
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VContainer/Assets/VContainer/Tests/LinkGenerator.meta
+++ b/VContainer/Assets/VContainer/Tests/LinkGenerator.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: fd7acdb05afd4804acab0872eb5cf13e
+timeCreated: 1679921275

--- a/VContainer/Assets/VContainer/Tests/LinkGenerator/Fixtures.meta
+++ b/VContainer/Assets/VContainer/Tests/LinkGenerator/Fixtures.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 84fa56e5800f4da0af18e18c807cb1fb
+timeCreated: 1679921306

--- a/VContainer/Assets/VContainer/Tests/LinkGenerator/Fixtures/FooMono1.cs
+++ b/VContainer/Assets/VContainer/Tests/LinkGenerator/Fixtures/FooMono1.cs
@@ -1,0 +1,7 @@
+using UnityEngine;
+
+namespace VContainer.Tests.LinkGenerator
+{
+    public class FooMono1 : MonoBehaviour { }
+    public class FooMono2 : MonoBehaviour { }
+}

--- a/VContainer/Assets/VContainer/Tests/LinkGenerator/Fixtures/FooMono1.cs.meta
+++ b/VContainer/Assets/VContainer/Tests/LinkGenerator/Fixtures/FooMono1.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 00c3322b94e24cff9e9edfa7c1fe5350
+timeCreated: 1679668584

--- a/VContainer/Assets/VContainer/Tests/LinkGenerator/Fixtures/FooScriptable1.cs
+++ b/VContainer/Assets/VContainer/Tests/LinkGenerator/Fixtures/FooScriptable1.cs
@@ -1,0 +1,7 @@
+using UnityEngine;
+
+namespace VContainer.Tests.LinkGenerator
+{
+    public class FooScriptable1 : ScriptableObject { }
+    public class FooScriptable2 : ScriptableObject { }
+}

--- a/VContainer/Assets/VContainer/Tests/LinkGenerator/Fixtures/FooScriptable1.cs.meta
+++ b/VContainer/Assets/VContainer/Tests/LinkGenerator/Fixtures/FooScriptable1.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 3d3e919e54ba4774887962b75192cbc2
+timeCreated: 1679668594

--- a/VContainer/Assets/VContainer/Tests/LinkGenerator/Fixtures/FooSerializable1.cs
+++ b/VContainer/Assets/VContainer/Tests/LinkGenerator/Fixtures/FooSerializable1.cs
@@ -1,0 +1,33 @@
+﻿using System;
+
+namespace VContainer.Tests.LinkGenerator
+{
+    [Serializable]
+    public abstract class BaseFoo
+    {
+    }
+
+    [Serializable]
+    public class DerivedBaseFoo1 : BaseFoo
+    {
+        public int test;
+    }
+
+    [Serializable]
+    public class DerivedBaseFoo2 : BaseFoo
+    {
+        public int test;
+    }
+
+    [Serializable]
+    public class FooSerializable1
+    {
+        public int fooField;
+    }
+    
+    [Serializable]
+    public class FooSerializable2
+    {
+        public int fooField;
+    }
+}

--- a/VContainer/Assets/VContainer/Tests/LinkGenerator/Fixtures/FooSerializable1.cs.meta
+++ b/VContainer/Assets/VContainer/Tests/LinkGenerator/Fixtures/FooSerializable1.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 56e0f65f47e94bd29311b4abdd75276e
+timeCreated: 1679921330

--- a/VContainer/Assets/VContainer/Tests/LinkGenerator/Fixtures/InjectFixtures.cs
+++ b/VContainer/Assets/VContainer/Tests/LinkGenerator/Fixtures/InjectFixtures.cs
@@ -1,0 +1,74 @@
+﻿using System.Collections.Generic;
+
+namespace VContainer.Tests.LinkGenerator.Fixtures
+{
+    public class FooEmptyCtor
+    {
+        public FooEmptyCtor() { }
+    }
+
+    public class Foo1ParamCtor
+    {
+        public Foo1ParamCtor(FooEmptyCtor _) { }
+    }
+
+    public class FooManyParamCtor
+    {
+        public FooManyParamCtor(FooEmptyCtor _1,
+            Dictionary<FooEmptyCtor, List<FooEmptyCtor>> _2,
+            int? _3,
+            float _4,
+            string _5) { }
+    }
+
+    public class FooManyCtors
+    {
+        public FooManyCtors()
+        {
+        }
+        
+        [Inject]
+        public FooManyCtors(FooEmptyCtor _1,
+            Dictionary<FooEmptyCtor, List<FooEmptyCtor>> _2,
+            int? _3,
+            float _4,
+            string _5) { }
+    }
+
+    public class FooFields
+    {
+        [Inject]
+        public FooEmptyCtor foo1;
+        public FooEmptyCtor foo2;
+    }
+
+    public class FooAutoProperty
+    {
+        [Inject]
+        public FooEmptyCtor foo1 { get; set; }
+    }
+
+    public class FooMethod
+    {
+        [Inject]
+        public void FooInject1() { }
+
+        [Inject]
+        public void FooInject2(FooEmptyCtor _1,
+            Dictionary<FooEmptyCtor, List<FooEmptyCtor>> _2,
+            int? _3,
+            float _4,
+            string _5) { }
+
+        [Inject]
+        public Dictionary<FooEmptyCtor, List<FooEmptyCtor>> FooInject3(FooEmptyCtor _1,
+            Dictionary<FooEmptyCtor, List<FooEmptyCtor>> _2,
+            int? _3,
+            float _4,
+            string _5) =>
+            null;
+
+        [Inject]
+        public int? FooInject4() => null;
+    }
+}

--- a/VContainer/Assets/VContainer/Tests/LinkGenerator/Fixtures/InjectFixtures.cs.meta
+++ b/VContainer/Assets/VContainer/Tests/LinkGenerator/Fixtures/InjectFixtures.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: c1cac39457414e759914f4c788075dc5
+timeCreated: 1679949520

--- a/VContainer/Assets/VContainer/Tests/LinkGenerator/Fixtures/LinkGeneratorTestScope.cs
+++ b/VContainer/Assets/VContainer/Tests/LinkGenerator/Fixtures/LinkGeneratorTestScope.cs
@@ -1,0 +1,33 @@
+﻿using UnityEngine;
+using VContainer.Unity;
+
+namespace VContainer.Tests.LinkGenerator
+{
+    public sealed class LinkGeneratorTestScope : LifetimeScope
+    {
+        public FooMono1 t1;
+        [SerializeField] private FooMono2 t2;
+        public FooScriptable1 t3;
+        [SerializeField] private FooScriptable2 t4;
+        [SerializeReference] public BaseFoo t5;
+        [SerializeReference] private BaseFoo t6;
+        public FooSerializable1 t8;
+        [SerializeField] private FooSerializable2 t9;
+        public AssetBundle t10;
+
+        protected override void Configure(IContainerBuilder builder)
+        {
+            builder.RegisterComponent(t1);
+            builder.RegisterComponent(t2);
+            builder.RegisterComponent(t3);
+            builder.RegisterComponent(t4);
+
+            builder.RegisterInstance(t5);
+            builder.RegisterInstance(t6);
+            builder.RegisterInstance(t8);
+            builder.RegisterInstance(t9);
+
+            builder.RegisterInstance(t10);
+        }
+    }
+}

--- a/VContainer/Assets/VContainer/Tests/LinkGenerator/Fixtures/LinkGeneratorTestScope.cs.meta
+++ b/VContainer/Assets/VContainer/Tests/LinkGenerator/Fixtures/LinkGeneratorTestScope.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 1ecd690af0a947baaa59323332304d8d
+timeCreated: 1679606506

--- a/VContainer/Assets/VContainer/Tests/LinkGenerator/LinkGeneratorTests.cs
+++ b/VContainer/Assets/VContainer/Tests/LinkGenerator/LinkGeneratorTests.cs
@@ -1,0 +1,30 @@
+﻿using System.Text;
+using System.Xml;
+using NUnit.Framework;
+using UnityEngine;
+using VContainer.Editor.LinkGenerator;
+using VContainer.Internal;
+using VContainer.Tests.LinkGenerator.Fixtures;
+
+namespace VContainer.Tests.LinkGenerator
+{
+    public class LinkGeneratorTests
+    {
+        [Test]
+        public void Test()
+        {
+            var xmlBuilder = new VContainerXmlLinkBuilder();
+            xmlBuilder.Add(TypeAnalyzer.Analyze(typeof(FooEmptyCtor)));
+            xmlBuilder.Add(TypeAnalyzer.Analyze(typeof(Foo1ParamCtor)));
+            xmlBuilder.Add(TypeAnalyzer.Analyze(typeof(FooManyParamCtor)));
+            xmlBuilder.Add(TypeAnalyzer.Analyze(typeof(FooManyCtors)));
+            xmlBuilder.Add(TypeAnalyzer.Analyze(typeof(FooFields)));
+            xmlBuilder.Add(TypeAnalyzer.Analyze(typeof(FooAutoProperty)));
+            xmlBuilder.Add(TypeAnalyzer.Analyze(typeof(FooMethod)));
+
+            var sb = new StringBuilder();
+            xmlBuilder.WriteTo(XmlWriter.Create(sb));
+            Debug.Log(sb.ToString());
+        }
+    }
+}

--- a/VContainer/Assets/VContainer/Tests/LinkGenerator/LinkGeneratorTests.cs.meta
+++ b/VContainer/Assets/VContainer/Tests/LinkGenerator/LinkGeneratorTests.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 3347cd68d83a4f76991680fcd12fe4f9
+timeCreated: 1679948759

--- a/VContainer/Assets/VContainer/Tests/VContainer.Tests.asmdef
+++ b/VContainer/Assets/VContainer/Tests/VContainer.Tests.asmdef
@@ -6,7 +6,8 @@
         "UnityEditor.TestRunner",
         "VContainer",
         "Unity.Entities",
-        "UniTask"
+        "UniTask",
+        "VContainer.LinkGenerator"
     ],
     "includePlatforms": [],
     "excludePlatforms": [


### PR DESCRIPTION
Hi @hadashiA,

I have mentioned (#363) that I want to add the auto-addition all registered classes in scopes to link.xml.
Here is proof of concept. I have already tested generation for `MonoBehaviours`, `ScriptableObject` classes and classes with `Serializable` attribute.

How does it works:
I made the same mechanism to turn on the feature as CodeGen. Via aditional asmdef `VContainer.EnableLinkGenerator`. You need to add that assebmly as dependency to your runtime asmdef to enable that feature. So enabling you can find in class `VContainerLinkerProcessor`. That class tries to find the assembly with `VContainer` and `VContainer.EnableLinkGenerator` dependency. And if they are exist It starts to analyze all types in picked asseblies.

The analyzer consists of:
1. Finding all lifetime scopes and create their instances
2. Finding all declared fields with `SerializedField` attribute or derived from `Component` or `ScriptableObject`.
3. Initializing all have found fields via `AddComponent`, `ScriptableObject.Create` and `Activator.CreateInstance`
4. Calling method `Cofigure` on `LifetimeScope` to register all dependencies which defined in lifetime scope
5. Geting all registered types from builder

Next, I have wrote a custom link.xml builder class (`VContainerXmlLinkBuilder`) which based om unity's `UnityEditor.Build.Pipeline.Utilities.LinkXmlGenerator` class, but more powerful. It allows to preserve methods, fields and properties without whole class preserving (as `LinkXmlGemerator` does). I think that preserving all members by default is so frustrating feature.

That feature works with Vcontainer as backbox and doesn't require to change any parts of runtime.

I want to get your comment about that idea before continue. Feel free to give feedback 😄 
If you approve that feature I will:
- Resolve all TODO's
- Write tests for all parts of generation
- Extend field initializing by adding support `SerializeReference` attribute and recurcive fields initialization for `Serializable` classes
- Add documentation to site

p.s. feature is draft, but you can test in the editor if you need. 