### PR TITLE
UniTask binding support from method

### DIFF
--- a/VContainer.StandaloneTests/AsyncRegisterTest.cs
+++ b/VContainer.StandaloneTests/AsyncRegisterTest.cs
@@ -1,0 +1,44 @@
+#if VCONTAINER_UNITASK_INTEGRATION
+using System.Threading.Tasks;
+using Cysharp.Threading.Tasks;
+using NUnit.Framework;
+
+namespace VContainer.Tests
+{
+    public class AsyncRegisterTest
+    {
+        [Test]
+        public async Task ResolveTypeFromAsyncMethod()
+        {
+            var builder = new ContainerBuilder();
+            builder.RegisterAsync(CreateAsync, Lifetime.Singleton);
+
+            var container = builder.Build();
+
+            var foo = await container.Resolve<UniTask<Foo>>();
+            Assert.That(foo, Is.TypeOf<Foo>());
+
+            UniTask<Foo> CreateAsync(IObjectResolver resolver) => UniTask.FromResult(new Foo());
+        }
+        
+        [Test]
+        public async Task ResolveFromResolveAsync()
+        {
+            var builder = new ContainerBuilder();
+            builder.Register<I2, NoDependencyServiceA>(Lifetime.Transient);
+
+            builder.RegisterAsync(Create, Lifetime.Scoped);
+
+            var container = builder.Build();
+            var resolved = await container.ResolveAsync<ServiceA>();
+            Assert.That(resolved, Is.InstanceOf<ServiceA>());
+            Assert.That(resolved.Service2, Is.InstanceOf<NoDependencyServiceA>());
+
+            UniTask<ServiceA> Create(IObjectResolver resolver)
+            {
+                return UniTask.FromResult(new ServiceA(resolver.Resolve<I2>()));
+            }
+        }
+    }
+}
+#endif

--- a/VContainer/Assets/VContainer/Runtime/ContainerAsyncBuilderExtensions.cs
+++ b/VContainer/Assets/VContainer/Runtime/ContainerAsyncBuilderExtensions.cs
@@ -1,0 +1,22 @@
+#if VCONTAINER_UNITASK_INTEGRATION
+using System;
+using System.Runtime.CompilerServices;
+using Cysharp.Threading.Tasks;
+using VContainer.Internal;
+
+namespace VContainer
+{
+    public static class ContainerAsyncBuilderExtensions
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static RegistrationBuilder RegisterAsync<TInterface>(
+            this IContainerBuilder builder,
+            Func<IObjectResolver, UniTask<TInterface>> implementationConfiguration,
+            Lifetime lifetime)
+            where TInterface : class
+        {
+            return builder.Register(new AsyncFuncRegistrationBuilder<TInterface>(implementationConfiguration, typeof(UniTask<TInterface>), lifetime));
+        }
+    }
+}
+#endif

--- a/VContainer/Assets/VContainer/Runtime/ContainerAsyncBuilderExtensions.cs.meta
+++ b/VContainer/Assets/VContainer/Runtime/ContainerAsyncBuilderExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bb57460a0abcc4ed4b309c5b7d3c899c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VContainer/Assets/VContainer/Runtime/IObjectResolverAsyncExtensions.cs
+++ b/VContainer/Assets/VContainer/Runtime/IObjectResolverAsyncExtensions.cs
@@ -1,0 +1,13 @@
+#if VCONTAINER_UNITASK_INTEGRATION
+using System.Runtime.CompilerServices;
+using Cysharp.Threading.Tasks;
+
+namespace VContainer
+{
+    public static class IObjectResolverAsyncExtensions
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static async UniTask<T> ResolveAsync<T>(this IObjectResolver resolver) => await resolver.Resolve<UniTask<T>>();
+    }
+}
+#endif

--- a/VContainer/Assets/VContainer/Runtime/IObjectResolverAsyncExtensions.cs.meta
+++ b/VContainer/Assets/VContainer/Runtime/IObjectResolverAsyncExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 71016da764db24bfb8e70e3a4b5350ec
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VContainer/Assets/VContainer/Runtime/Internal/AsyncFuncRegistrationBuilder.cs
+++ b/VContainer/Assets/VContainer/Runtime/Internal/AsyncFuncRegistrationBuilder.cs
@@ -1,0 +1,26 @@
+#if VCONTAINER_UNITASK_INTEGRATION
+using System;
+using Cysharp.Threading.Tasks;
+
+namespace VContainer.Internal;
+
+internal sealed class AsyncFuncRegistrationBuilder<T> : RegistrationBuilder
+{
+    private readonly Func<IObjectResolver, UniTask<T>> implementationProvider;
+
+    public AsyncFuncRegistrationBuilder(
+        Func<IObjectResolver, UniTask<T>> implementationProvider,
+        Type implementationType,
+        Lifetime lifetime) 
+        : base(implementationType, lifetime)
+    {
+        this.implementationProvider = implementationProvider;
+    }
+
+    public override Registration Build()
+    {
+        var spawner = new AsyncFuncInstanceProvider<T>(implementationProvider);
+        return new Registration(ImplementationType, Lifetime, InterfaceTypes, spawner);
+    }
+}
+#endif

--- a/VContainer/Assets/VContainer/Runtime/Internal/AsyncFuncRegistrationBuilder.cs
+++ b/VContainer/Assets/VContainer/Runtime/Internal/AsyncFuncRegistrationBuilder.cs
@@ -2,25 +2,26 @@
 using System;
 using Cysharp.Threading.Tasks;
 
-namespace VContainer.Internal;
-
-internal sealed class AsyncFuncRegistrationBuilder<T> : RegistrationBuilder
+namespace VContainer.Internal
 {
-    private readonly Func<IObjectResolver, UniTask<T>> implementationProvider;
-
-    public AsyncFuncRegistrationBuilder(
-        Func<IObjectResolver, UniTask<T>> implementationProvider,
-        Type implementationType,
-        Lifetime lifetime) 
-        : base(implementationType, lifetime)
+    internal sealed class AsyncFuncRegistrationBuilder<T> : RegistrationBuilder
     {
-        this.implementationProvider = implementationProvider;
-    }
+        private readonly Func<IObjectResolver, UniTask<T>> implementationProvider;
 
-    public override Registration Build()
-    {
-        var spawner = new AsyncFuncInstanceProvider<T>(implementationProvider);
-        return new Registration(ImplementationType, Lifetime, InterfaceTypes, spawner);
+        public AsyncFuncRegistrationBuilder(
+            Func<IObjectResolver, UniTask<T>> implementationProvider,
+            Type implementationType,
+            Lifetime lifetime)
+            : base(implementationType, lifetime)
+        {
+            this.implementationProvider = implementationProvider;
+        }
+
+        public override Registration Build()
+        {
+            var spawner = new AsyncFuncInstanceProvider<T>(implementationProvider);
+            return new Registration(ImplementationType, Lifetime, InterfaceTypes, spawner);
+        }
     }
 }
 #endif

--- a/VContainer/Assets/VContainer/Runtime/Internal/AsyncFuncRegistrationBuilder.cs.meta
+++ b/VContainer/Assets/VContainer/Runtime/Internal/AsyncFuncRegistrationBuilder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1b4abfdea6ba3497db14158ef618c7dc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VContainer/Assets/VContainer/Runtime/Internal/InstanceProviders/AsycnFuncInstanceProvider.cs
+++ b/VContainer/Assets/VContainer/Runtime/Internal/InstanceProviders/AsycnFuncInstanceProvider.cs
@@ -1,0 +1,21 @@
+#if VCONTAINER_UNITASK_INTEGRATION
+using System;
+using System.Runtime.CompilerServices;
+using Cysharp.Threading.Tasks;
+
+namespace VContainer.Internal
+{
+    internal sealed class AsyncFuncInstanceProvider<T> : IInstanceProvider
+    {
+        private readonly Func<IObjectResolver, UniTask<T>> implementationProvider;
+
+        public AsyncFuncInstanceProvider(Func<IObjectResolver, UniTask<T>> implementationProvider)
+        {
+            this.implementationProvider = implementationProvider;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public object SpawnInstance(IObjectResolver resolver) => implementationProvider(resolver);
+    }
+}
+#endif

--- a/VContainer/Assets/VContainer/Runtime/Internal/InstanceProviders/AsycnFuncInstanceProvider.cs.meta
+++ b/VContainer/Assets/VContainer/Runtime/Internal/InstanceProviders/AsycnFuncInstanceProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: eb2a48217d309478eaa81f37a0f515eb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### What I did:
I added a generic 
AsyncFuncInstanceProvider<T> : IInstanceProvider
And
AsyncFuncRegistrationBuilder<T> : RegistrationBuilder

which bind UniTask<T> instead of just T

Then added 2 new extension methods:
RegisterAsync<TInterface> which is used to bind UniTask<TInterface> from a method
ResolveAsync<TInterface> which return UniTask<TInterface> instead of TInterface

I also added a tests class to prove it works

and lastly wrapped all in VCONTAINER_UNITASK_INTEGRATION define to avoid compilation error in projects without UniTask

### Why?
I'm not sure what the best way to tackle async injections in DI without tackling it somehow from the root which would make things unreasonably complex, but I thought maybe supporting UniTask injection from method (which is currently not supported because UniTask is a struct) and adding a ResolveAsync extension will be better the nothing. but @hadashiA, tell me what you think and if I might miss something.