### PR TITLE
Fixed injection on MonoBehaviours not working if the registration was made using base class identifier

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/Unity/ComponentRegistrationBuilder.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/ComponentRegistrationBuilder.cs
@@ -70,23 +70,25 @@ namespace VContainer.Unity
 
         public override Registration Build()
         {
-            var injector = InjectorCache.GetOrBuild(ImplementationType);
             IInstanceProvider provider;
 
             if (instance != null)
             {
+                var injector = InjectorCache.GetOrBuild(ImplementationType);
                 provider = new ExistingComponentProvider(instance, injector, Parameters, destination.DontDestroyOnLoad);
             }
             else if (scene.IsValid())
             {
-                provider = new FindComponentProvider(ImplementationType, injector, Parameters, in scene, in destination);
+                provider = new FindComponentProvider(ImplementationType, Parameters, in scene, in destination);
             }
             else if (prefab != null)
             {
+                var injector = InjectorCache.GetOrBuild(prefab.GetType());
                 provider = new PrefabComponentProvider(prefab, injector, Parameters, in destination);
             }
             else
             {
+                var injector = InjectorCache.GetOrBuild(ImplementationType);
                 provider = new NewGameObjectProvider(ImplementationType, injector, Parameters, in destination, gameObjectName);
             }
             return new Registration(ImplementationType, Lifetime, InterfaceTypes, provider);

--- a/VContainer/Assets/VContainer/Runtime/Unity/InstanceProviders/FindComponentProvider.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/InstanceProviders/FindComponentProvider.cs
@@ -2,26 +2,24 @@ using System;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.SceneManagement;
+using VContainer.Internal;
 
 namespace VContainer.Unity
 {
     sealed class FindComponentProvider : IInstanceProvider
     {
         readonly Type componentType;
-        readonly IInjector injector;
         readonly IReadOnlyList<IInjectParameter> customParameters;
         ComponentDestination destination;
         Scene scene;
 
         public FindComponentProvider(
             Type componentType,
-            IInjector injector,
             IReadOnlyList<IInjectParameter> customParameters,
             in Scene scene,
             in ComponentDestination destination)
         {
             this.componentType = componentType;
-            this.injector = injector;
             this.customParameters = customParameters;
             this.scene = scene;
             this.destination = destination;
@@ -61,6 +59,7 @@ namespace VContainer.Unity
 
             if (component is MonoBehaviour monoBehaviour)
             {
+                var injector = InjectorCache.GetOrBuild(monoBehaviour.GetType());
                 injector.Inject(monoBehaviour, resolver, customParameters);
             }
 

--- a/VContainer/Assets/VContainer/Tests/Unity/Fixtures/SampleBaseMonoBehaviour.cs
+++ b/VContainer/Assets/VContainer/Tests/Unity/Fixtures/SampleBaseMonoBehaviour.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+namespace VContainer.Tests.Unity
+{
+    public abstract class SampleBaseMonoBehaviour : MonoBehaviour
+    {
+        
+    }
+}

--- a/VContainer/Assets/VContainer/Tests/Unity/Fixtures/SampleBaseMonoBehaviour.cs.meta
+++ b/VContainer/Assets/VContainer/Tests/Unity/Fixtures/SampleBaseMonoBehaviour.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: a3f7d86a35824244875843539eeef96b
+timeCreated: 1696301883

--- a/VContainer/Assets/VContainer/Tests/Unity/Fixtures/SampleDerivedMonoBehaviour.cs
+++ b/VContainer/Assets/VContainer/Tests/Unity/Fixtures/SampleDerivedMonoBehaviour.cs
@@ -1,0 +1,13 @@
+namespace VContainer.Tests.Unity
+{
+    public sealed class SampleDerivedMonoBehaviour : SampleBaseMonoBehaviour
+    {
+        public ServiceA Service;
+        
+        [Inject]
+        public void Construct(ServiceA service)
+        {
+            Service = service;
+        }
+    }
+}

--- a/VContainer/Assets/VContainer/Tests/Unity/Fixtures/SampleDerivedMonoBehaviour.cs.meta
+++ b/VContainer/Assets/VContainer/Tests/Unity/Fixtures/SampleDerivedMonoBehaviour.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: e7a25677860f43b59f94f01c8dbaa57c
+timeCreated: 1696301943

--- a/VContainer/Assets/VContainer/Tests/Unity/UnityContainerBuilderTest.cs
+++ b/VContainer/Assets/VContainer/Tests/Unity/UnityContainerBuilderTest.cs
@@ -63,6 +63,22 @@ namespace VContainer.Tests.Unity
 
             Assert.That(container.Resolve<IComponent>(), Is.EqualTo(component));
         }
+        
+        [Test]
+        public void RegisterComponentUsingBaseClass()
+        {
+            SampleBaseMonoBehaviour existingComponent = new GameObject("Sample")
+                .AddComponent<SampleDerivedMonoBehaviour>();
+
+            var builder = new ContainerBuilder();
+            builder.Register<ServiceA>(Lifetime.Transient);
+            builder.RegisterComponent(existingComponent);
+            var container = builder.Build();
+            
+            var target = (SampleDerivedMonoBehaviour) container.Resolve<SampleBaseMonoBehaviour>();
+
+            Assert.That(target.Service, Is.InstanceOf<ServiceA>());
+        }
 
         [Test]
         public void RegisterComponentWithAutoInjection()
@@ -217,6 +233,21 @@ namespace VContainer.Tests.Unity
         }
 
         [Test]
+        public void RegisterComponentInHierarchyUsingBaseClass()
+        {
+            var go = new GameObject("Sample");
+            var target = go.AddComponent<SampleDerivedMonoBehaviour>();
+            
+            var lifetimeScope = LifetimeScope.Create(builder =>
+            {
+                builder.Register<ServiceA>(Lifetime.Transient);
+                builder.RegisterComponentInHierarchy<SampleBaseMonoBehaviour>();
+            });
+
+            Assert.That(target.Service, Is.InstanceOf<ServiceA>());
+        }
+
+        [Test]
         public void RegisterComponentOnNewGameObject()
         {
             var builder = new ContainerBuilder();
@@ -280,6 +311,21 @@ namespace VContainer.Tests.Unity
             Assert.That(resolved2.transform.parent, Is.EqualTo(go1.transform));
             Assert.That(resolved1, Is.Not.EqualTo(resolved2));
             Assert.That(prefab.gameObject.activeSelf, Is.True);
+        }
+        
+        [Test]
+        public void RegisterComponentInNewPrefabUsingBaseClass()
+        {
+            SampleBaseMonoBehaviour prefab = new GameObject("Sample").AddComponent<SampleDerivedMonoBehaviour>();
+
+            var builder = new ContainerBuilder();
+            builder.Register<ServiceA>(Lifetime.Transient);
+            builder.RegisterComponentInNewPrefab(prefab, Lifetime.Singleton);
+            var container = builder.Build();
+            
+            var target = (SampleDerivedMonoBehaviour) container.Resolve<SampleBaseMonoBehaviour>();
+
+            Assert.That(target.Service, Is.InstanceOf<ServiceA>());
         }
 
         [Test]


### PR DESCRIPTION
Unit tests `RegisterComponentInHierarchyUsingBaseClass` and `RegisterComponentInNewPrefabUsingBaseClass` highlight the issue.
Fixed `FindComponentProvider` and `PrefabComponentProvider` so they actually inject the type that is being found/instantiated instead of the base type.