### PR TITLE
Increase visibility of RegistrationBuilder and InjectorCache to make VContainer more extensible.

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/Internal/InjectorCache.cs
+++ b/VContainer/Assets/VContainer/Runtime/Internal/InjectorCache.cs
@@ -4,7 +4,7 @@ using System.Reflection;
 
 namespace VContainer.Internal
 {
-    static class InjectorCache
+    public static class InjectorCache
     {
         static readonly ConcurrentDictionary<Type, IInjector> Injectors = new ConcurrentDictionary<Type, IInjector>();
 

--- a/VContainer/Assets/VContainer/Runtime/RegistrationBuilder.cs
+++ b/VContainer/Assets/VContainer/Runtime/RegistrationBuilder.cs
@@ -6,11 +6,11 @@ namespace VContainer
 {
     public class RegistrationBuilder
     {
-        internal readonly Type ImplementationType;
-        internal readonly Lifetime Lifetime;
+        protected internal readonly Type ImplementationType;
+        protected internal readonly Lifetime Lifetime;
 
-        internal List<Type> InterfaceTypes;
-        internal List<IInjectParameter> Parameters;
+        protected internal List<Type> InterfaceTypes;
+        protected internal List<IInjectParameter> Parameters;
 
         public RegistrationBuilder(Type implementationType, Lifetime lifetime)
         {


### PR DESCRIPTION
With members of `RegistrationBuilder` being `internal`, it's very difficult to create your own project-specific registrations. 

I increased visiblity of members inside `RegistrationBuilder` to `protected internal`. This should allow classes that inherit from `RegistrationBuilder` to have access to those fields. 

I also changed the visibility of `InjectorCache` to `public`. This is needed for the cases that a custom `RegistrationBuilder` needs to be made. 