### PR TITLE
Allow installers to be added to localExtraInstallers

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/Unity/LifetimeScope.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/LifetimeScope.cs
@@ -47,6 +47,23 @@ namespace VContainer.Unity
             }
         }
 
+        public readonly struct ExtraLocalInstallationScope : IDisposable
+        {
+            private readonly LifetimeScope _scope;
+            private readonly IInstaller _installer;
+
+            public ExtraLocalInstallationScope(LifetimeScope scope, IInstaller installer)
+            {
+                _installer = installer;
+                _scope = scope;
+            }
+            
+            public void Dispose()
+            {
+                _scope.localExtraInstallers.Remove(_installer);
+            }
+        }
+
         [SerializeField]
         public ParentReference parentReference;
 
@@ -258,6 +275,12 @@ namespace VContainer.Unity
         public TScope CreateChildFromPrefab<TScope>(TScope prefab, Action<IContainerBuilder> installation)
             where TScope : LifetimeScope
             => CreateChildFromPrefab(prefab, new ActionInstaller(installation));
+
+        public ExtraLocalInstallationScope EnqueueLocalInstaller(IInstaller installer)
+        {
+            localExtraInstallers.Add(installer);
+            return new ExtraLocalInstallationScope(this, installer);
+        }
 
         void InstallTo(IContainerBuilder builder)
         {


### PR DESCRIPTION
As it is, even though `localExtraInstallers` is a list, it's not possible to add more than one installer to it. 

I added a `EnqueueLocalInstaller` function to `LifetimeScope`, which allows users to add more installers to `localExtraInstallers` list. This function returns an `IDisposable` struct which removes the added installer.