### PR TITLE
Fix diagnostic windows are not updating realtime

### DIFF
--- a/VContainer/Assets/VContainer/Editor/Diagnostics/VContainerDiagnosticsWindow.cs
+++ b/VContainer/Assets/VContainer/Editor/Diagnostics/VContainerDiagnosticsWindow.cs
@@ -66,6 +66,12 @@ namespace VContainer.Editor.Diagnostics
             Repaint();
         }
 
+        void OnPlayModeStateChange(PlayModeStateChange state)
+        {
+            treeView.ReloadAndSort();
+            Repaint();
+        }
+
         void OnEnable()
         {
             window = this; // set singleton.
@@ -76,11 +82,13 @@ namespace VContainer.Editor.Diagnostics
             searchField = new SearchField();
 
             DiagnositcsContext.OnContainerBuilt += Reload;
+            EditorApplication.playModeStateChanged += OnPlayModeStateChange;
         }
 
         void OnDisable()
         {
             DiagnositcsContext.OnContainerBuilt -= Reload;
+            EditorApplication.playModeStateChanged -= OnPlayModeStateChange;
         }
 
         void OnGUI()

--- a/VContainer/Assets/VContainer/Runtime/Container.cs
+++ b/VContainer/Assets/VContainer/Runtime/Container.cs
@@ -110,6 +110,10 @@ namespace VContainer
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Dispose()
         {
+            if (Diagnostics != null)
+            {
+                Diagnostics.Clear();
+            }
             disposables.Dispose();
             sharedInstances.Clear();
         }
@@ -223,6 +227,10 @@ namespace VContainer
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Dispose()
         {
+            if (Diagnostics != null)
+            {
+                Diagnostics.Clear();
+            }
             rootScope.Dispose();
             disposables.Dispose();
             sharedInstances.Clear();


### PR DESCRIPTION
1. When a container is disposed, the diagnostics window still shows the lifescope and its dependencies. (#387)
In this situation, when user clicks scope/dependency that already disposed to view the details, it shows an error.
![이미지](https://github.com/hadashiA/VContainer/assets/19837403/6a037be3-8b18-46fc-b22e-cad52c4403c0)

This PR fixes the error by clearing the diagnostics information when a container is disposed.

2. On editor's play mode start / end, diagnostic windows are not automatically updated.
Using `EditorApplication.playModeStateChanged`, diagnostic windows are conveniently updated.