### PR TITLE
Added option to lazily create paramaters and use the scope's resolver

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/IInjectParameter.cs
+++ b/VContainer/Assets/VContainer/Runtime/IInjectParameter.cs
@@ -5,6 +5,6 @@ namespace VContainer
     public interface IInjectParameter
     {
         bool Match(Type parameterType, string parameterName);
-        object Value { get; }
+        object GetValue(IObjectResolver resolver);
     }
 }

--- a/VContainer/Assets/VContainer/Runtime/IObjectResolverExtensions.cs
+++ b/VContainer/Assets/VContainer/Runtime/IObjectResolverExtensions.cs
@@ -28,7 +28,7 @@ namespace VContainer
                     var parameter = parameters[i];
                     if (parameter.Match(parameterType, parameterName))
                     {
-                        return parameter.Value;
+                        return parameter.GetValue(resolver);
                     }
                 }
             }

--- a/VContainer/Assets/VContainer/Runtime/Internal/InjectParameter.cs
+++ b/VContainer/Assets/VContainer/Runtime/Internal/InjectParameter.cs
@@ -5,7 +5,7 @@ namespace VContainer.Internal
     sealed class TypedParameter : IInjectParameter
     {
         public readonly Type Type;
-        public object Value { get; }
+        public readonly object Value;
 
         public TypedParameter(Type type, object value)
         {
@@ -14,12 +14,36 @@ namespace VContainer.Internal
         }
 
         public bool Match(Type parameterType, string _) => parameterType == Type;
+        
+        public object GetValue(IObjectResolver _)
+        {
+            return Value;
+        }
+    }
+    
+    sealed class FuncTypedParameter : IInjectParameter
+    {
+        public readonly Type Type;
+        public readonly Func<IObjectResolver, object> Func;
+
+        public FuncTypedParameter(Type type, Func<IObjectResolver, object> func)
+        {
+            Type = type;
+            Func = func;
+        }
+
+        public bool Match(Type parameterType, string _) => parameterType == Type;
+        
+        public object GetValue(IObjectResolver resolver)
+        {
+            return Func(resolver);
+        }
     }
 
     sealed class NamedParameter : IInjectParameter
     {
         public readonly string Name;
-        public object Value { get; }
+        public readonly object Value;
 
         public NamedParameter(string name, object value)
         {
@@ -28,5 +52,29 @@ namespace VContainer.Internal
         }
 
         public bool Match(Type _, string parameterName) => parameterName == Name;
+        
+        public object GetValue(IObjectResolver _)
+        {
+            return Value;
+        }
+    }
+    
+    sealed class FuncNamedParameter : IInjectParameter
+    {
+        public readonly string Name;
+        public readonly Func<IObjectResolver, object> Func;
+
+        public FuncNamedParameter(string name, Func<IObjectResolver, object> func)
+        {
+            Name = name;
+            Func = func;
+        }
+
+        public bool Match(Type _, string parameterName) => parameterName == Name;
+        
+        public object GetValue(IObjectResolver resolver)
+        {
+            return Func(resolver);
+        }
     }
 }

--- a/VContainer/Assets/VContainer/Runtime/RegistrationBuilder.cs
+++ b/VContainer/Assets/VContainer/Runtime/RegistrationBuilder.cs
@@ -90,6 +90,13 @@ namespace VContainer
             Parameters.Add(new NamedParameter(name, value));
             return this;
         }
+        
+        public RegistrationBuilder WithParameter(string name, Func<IObjectResolver, object> value)
+        {
+            Parameters = Parameters ?? new List<IInjectParameter>();
+            Parameters.Add(new FuncNamedParameter(name, value));
+            return this;
+        }
 
         public RegistrationBuilder WithParameter(Type type, object value)
         {
@@ -97,10 +104,27 @@ namespace VContainer
             Parameters.Add(new TypedParameter(type, value));
             return this;
         }
+        
+        public RegistrationBuilder WithParameter(Type type, Func<IObjectResolver, object> value)
+        {
+            Parameters = Parameters ?? new List<IInjectParameter>();
+            Parameters.Add(new FuncTypedParameter(type, value));
+            return this;
+        }
 
         public RegistrationBuilder WithParameter<TParam>(TParam value)
         {
             return WithParameter(typeof(TParam), value);
+        }
+        
+        public RegistrationBuilder WithParameter<TParam>(Func<IObjectResolver, TParam> value)
+        {
+            return WithParameter(typeof(TParam), resolver => value(resolver));
+        }
+        
+        public RegistrationBuilder WithParameter<TParam>(Func<TParam> value)
+        {
+            return WithParameter(typeof(TParam), _ => value());
         }
 
         void AddInterfaceType(Type interfaceType)

--- a/VContainer/Assets/VContainer/Tests/ContainerTest.cs
+++ b/VContainer/Assets/VContainer/Tests/ContainerTest.cs
@@ -399,6 +399,17 @@ namespace VContainer.Tests
                 var resolved = container.Resolve<HasMethodInjection>();
                 Assert.That(resolved.Service2, Is.EqualTo(paramValue));
             }
+            
+            {
+                var builder = new ContainerBuilder();
+                builder.Register<I2, NoDependencyServiceA>(Lifetime.Scoped);
+                builder.Register<HasMethodInjection>(Lifetime.Scoped)
+                    .WithParameter(resolver => resolver.Resolve<I2>());
+
+                var container = builder.Build();
+                var resolved = container.Resolve<HasMethodInjection>();
+                Assert.That(resolved.Service2, Is.Not.Null);
+            }
         }
 
         [Test]


### PR DESCRIPTION
Changed the interface IInjectParameter ( from: Value { get; }  to: GetValue(IObjectResolver resolver) )

And added new variations of it called FuncTypedParameter and FuncNamedParameter.

This allows you to add parameters to registrations the can be created lazily/created per transient resolve and can use the IObjectResolver that was used to create the object.

It would be nice to also add in the future the the option to declare a parameter as single (in case the parent register is not)

Added Unit Tests

Edit: Also added option to resolve a parameter from an injector in a separate [branch](https://github.com/AlonTalmi/VContainer/tree/InjectedInstanceParameter)
