### PR TITLE
IContainerBuilder RegisterOnDisposeCallback option

### DIFF
--- a/VContainer/Assets/VContainer/Tests/ContainerTest.cs
+++ b/VContainer/Assets/VContainer/Tests/ContainerTest.cs
@@ -518,5 +518,24 @@ namespace VContainer.Tests
             var ctorInjectable = new ServiceA(new NoDependencyServiceA());
             Assert.DoesNotThrow(() => container.Inject(ctorInjectable));
         }
+
+        [Test]
+        public void OnContainerDisposeCallback()
+        {
+            NoDependencyServiceA resolvedJustBeforeDispose = null;
+            
+            var builder = new ContainerBuilder();
+            
+            builder.Register<NoDependencyServiceA>(Lifetime.Scoped);
+            builder.RegisterDisposeCallback(resolver => resolvedJustBeforeDispose = resolver.Resolve<NoDependencyServiceA>());
+
+            var container = builder.Build();
+            
+            Assert.That(resolvedJustBeforeDispose, Is.Null);
+            
+            container.Dispose();
+            
+            Assert.That(resolvedJustBeforeDispose, Is.Not.Null);
+        }
     }
 }


### PR DESCRIPTION
I added the option to listen to when any container created by the builder is disposed (but not scoped child containers).

I added a RegisterDisposeCallback to interface IContainerBuilder.

The dispose callback is called just before the container is disposed.

Added Unit Tests