### PR TITLE
Added option to TryGetSharedInstance to IObjectResolver

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/IObjectResolverExtensions.cs
+++ b/VContainer/Assets/VContainer/Runtime/IObjectResolverExtensions.cs
@@ -8,6 +8,28 @@ namespace VContainer
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static T Resolve<T>(this IObjectResolver resolver) => (T)resolver.Resolve(typeof(T));
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryGetSharedInstance<T>(this IObjectResolver resolver, out T instance)
+        {
+            if (!resolver.TryGetSharedInstance(typeof(T), out var boxed))
+            {
+                instance = default;
+                return false;
+            }
+
+            instance = (T)boxed;
+            return true;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T GetSharedInstanceOrDefault<T>(this IObjectResolver resolver)
+        {
+            if (resolver.TryGetSharedInstance<T>(out var instance))
+                return instance;
+            
+            return default;
+        }
 
         // Using from CodeGen
         [Preserve]

--- a/VContainer/Assets/VContainer/Tests/ContainerTest.cs
+++ b/VContainer/Assets/VContainer/Tests/ContainerTest.cs
@@ -518,5 +518,75 @@ namespace VContainer.Tests
             var ctorInjectable = new ServiceA(new NoDependencyServiceA());
             Assert.DoesNotThrow(() => container.Inject(ctorInjectable));
         }
+
+        [Test]
+        public void TryGetSharedInstance()
+        {
+            {
+                const Lifetime lifetime = Lifetime.Singleton;
+                
+                var builder = new ContainerBuilder();
+                bool serviceWasResolved = false;
+
+                builder.Register(_ =>
+                {
+                    serviceWasResolved = true;
+                    return new NoDependencyServiceA();
+                }, lifetime);
+                
+                var container = builder.Build();
+                
+                Assert.That(container.TryGetSharedInstance(typeof(NoDependencyServiceA), out _), Is.False);
+                Assert.That(serviceWasResolved, Is.False);
+                
+                _ = container.Resolve<NoDependencyServiceA>();
+                
+                Assert.That(container.TryGetSharedInstance(typeof(NoDependencyServiceA), out _), Is.True);
+            }
+            
+            {
+                const Lifetime lifetime = Lifetime.Scoped;
+                
+                var builder = new ContainerBuilder();
+                bool serviceWasResolved = false;
+
+                builder.Register(_ =>
+                {
+                    serviceWasResolved = true;
+                    return new NoDependencyServiceA();
+                }, lifetime);
+                
+                var container = builder.Build();
+                
+                Assert.That(container.TryGetSharedInstance(typeof(NoDependencyServiceA), out _), Is.False);
+                Assert.That(serviceWasResolved, Is.False);
+                
+                _ = container.Resolve<NoDependencyServiceA>();
+                
+                Assert.That(container.TryGetSharedInstance(typeof(NoDependencyServiceA), out _), Is.True);
+            }
+            
+            {
+                const Lifetime lifetime = Lifetime.Transient;
+                
+                var builder = new ContainerBuilder();
+                bool serviceWasResolved = false;
+
+                builder.Register(_ =>
+                {
+                    serviceWasResolved = true;
+                    return new NoDependencyServiceA();
+                }, lifetime);
+                
+                var container = builder.Build();
+                
+                Assert.That(container.TryGetSharedInstance(typeof(NoDependencyServiceA), out _), Is.False);
+                Assert.That(serviceWasResolved, Is.False);
+                
+                _ = container.Resolve<NoDependencyServiceA>();
+                
+                Assert.That(container.TryGetSharedInstance(typeof(NoDependencyServiceA), out _), Is.False);
+            }
+        }
     }
 }


### PR DESCRIPTION
Added to IObjectResolver interface a TryGetSharedInstance which only returns if a shared instance of the request type (or Registration) exists and was created.

Can be used to update instances of a type (if they're not transient) at runtime without resolving them needlessly.

I also added generic extension methods and Unit Tests