### PR TITLE
Added AsNoneLazy ContainerBuilder extension

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/ContainerBuilderExtensions.cs
+++ b/VContainer/Assets/VContainer/Runtime/ContainerBuilderExtensions.cs
@@ -130,6 +130,13 @@ namespace VContainer
             Func<IObjectResolver, Func<TParam1, TParam2, TParam3, TParam4, T>> factoryFactory,
             Lifetime lifetime)
             => builder.Register(new FuncRegistrationBuilder(factoryFactory, typeof(Func<TParam1, TParam2, TParam3, TParam4, T>), lifetime));
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static IContainerBuilder AsNoneLazy<T>(this IContainerBuilder builder)
+        {
+            builder.RegisterBuildCallback(resolver => _ = resolver.Resolve<T>());
+            return builder;
+        }
 
         [Obsolete("IObjectResolver is registered by default. This method does nothing.")]
         public static void RegisterContainer(this IContainerBuilder builder)

--- a/VContainer/Assets/VContainer/Tests/ContainerTest.cs
+++ b/VContainer/Assets/VContainer/Tests/ContainerTest.cs
@@ -518,5 +518,25 @@ namespace VContainer.Tests
             var ctorInjectable = new ServiceA(new NoDependencyServiceA());
             Assert.DoesNotThrow(() => container.Inject(ctorInjectable));
         }
+
+        [Test]
+        public void AsNoneLazy()
+        {
+            var builder = new ContainerBuilder();
+
+            bool wasResolved = false;
+            
+            builder.Register(_ =>
+            {
+                wasResolved = true;
+                return new NoDependencyServiceA();
+            },  Lifetime.Scoped);
+
+            builder.AsNoneLazy<NoDependencyServiceA>();
+            
+            _ = builder.Build();
+            
+            Assert.That(wasResolved, Is.True);
+        }
     }
 }


### PR DESCRIPTION
I added a simple extension method that registers a build callback that resolves the type requested.

Unlike Zenject and other similar DI libraries where NoneLazy is marked during the registration phase here it's controlled in the container level. I personally like it, but can see why you might not.

Anyway, I also added a Unit Test.