### PR TITLE
Exposed IObjectResolver to prefab and parent finders in ComponentRegistrationBuilder

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/Unity/ContainerBuilderUnityExtensions.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/ContainerBuilderUnityExtensions.cs
@@ -168,14 +168,15 @@ namespace VContainer.Unity
             return builder.RegisterComponentOnNewGameObject(typeof(T), lifetime, newGameObjectName);
         }
 
-        public static ComponentRegistrationBuilder RegisterComponentInNewPrefab<T>(
+        public static ComponentRegistrationBuilder RegisterComponentInNewPrefab(
             this IContainerBuilder builder,
-            Type type,
-            T prefab,
+            Type interfaceType,
+            Component prefab,
             Lifetime lifetime)
-            where T : Component
         {
-            return builder.Register(new ComponentRegistrationBuilder(prefab, type, lifetime));
+            var componentRegistrationBuilder = builder.Register(new ComponentRegistrationBuilder(_ => prefab, prefab.GetType(), lifetime));
+            componentRegistrationBuilder.As(interfaceType);
+            return componentRegistrationBuilder;
         }
 
         public static ComponentRegistrationBuilder RegisterComponentInNewPrefab<T>(
@@ -185,6 +186,26 @@ namespace VContainer.Unity
             where T : Component
         {
             return builder.RegisterComponentInNewPrefab(typeof(T), prefab, lifetime);
+        }
+        
+        public static ComponentRegistrationBuilder RegisterComponentInNewPrefab<T>(
+            this IContainerBuilder builder,
+            Func<IObjectResolver, T> prefab,
+            Lifetime lifetime)
+            where T : Component
+        {
+            return builder.Register(new ComponentRegistrationBuilder(prefab, typeof(T), lifetime));
+        }
+        
+        public static ComponentRegistrationBuilder RegisterComponentInNewPrefab<TInterface, TImplement>(
+            this IContainerBuilder builder,
+            Func<IObjectResolver, TImplement> prefab,
+            Lifetime lifetime)
+            where TImplement : Component, TInterface
+        {
+            var componentRegistrationBuilder = builder.Register(new ComponentRegistrationBuilder(prefab, typeof(TImplement), lifetime));
+            componentRegistrationBuilder.As<TInterface>();
+            return componentRegistrationBuilder;
         }
 
 #if VCONTAINER_ECS_INTEGRATION

--- a/VContainer/Assets/VContainer/Runtime/Unity/InstanceProviders/FindComponentProvider.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/InstanceProviders/FindComponentProvider.cs
@@ -29,7 +29,7 @@ namespace VContainer.Unity
         {
             var component = default(Component);
 
-            var parent = destination.GetParent();
+            var parent = destination.GetParent(resolver);
             if (parent != null)
             {
                 component = parent.GetComponentInChildren(componentType, true);

--- a/VContainer/Assets/VContainer/Runtime/Unity/InstanceProviders/NewGameObjectProvider.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/InstanceProviders/NewGameObjectProvider.cs
@@ -34,7 +34,7 @@ namespace VContainer.Unity
             var gameObject = new GameObject(name);
             gameObject.SetActive(false);
 
-            var parent = destination.GetParent();
+            var parent = destination.GetParent(resolver);
             if (parent != null)
             {
                 gameObject.transform.SetParent(parent);

--- a/VContainer/Assets/VContainer/Runtime/Unity/InstanceProviders/PrefabComponentProvider.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/InstanceProviders/PrefabComponentProvider.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -7,30 +8,32 @@ namespace VContainer.Unity
     {
         readonly IInjector injector;
         readonly IReadOnlyList<IInjectParameter> customParameters;
-        readonly Component prefab;
+        readonly Func<IObjectResolver, Component> prefabFinder;
         ComponentDestination destination;
 
         public PrefabComponentProvider(
-            Component prefab,
+            Func<IObjectResolver, Component> prefabFinder,
             IInjector injector,
             IReadOnlyList<IInjectParameter> customParameters,
             in ComponentDestination destination)
         {
             this.injector = injector;
             this.customParameters = customParameters;
-            this.prefab = prefab;
+            this.prefabFinder = prefabFinder;
             this.destination = destination;
         }
 
         public object SpawnInstance(IObjectResolver resolver)
         {
+            var prefab = prefabFinder(resolver);
+            var parent = destination.GetParent(resolver);
+            
             var wasActive = prefab.gameObject.activeSelf;
             if (wasActive)
             {
                 prefab.gameObject.SetActive(false);
             }
-
-            var parent = destination.GetParent();
+            
             var component = parent != null
                 ? UnityEngine.Object.Instantiate(prefab, parent)
                 : UnityEngine.Object.Instantiate(prefab);


### PR DESCRIPTION
When registering a component the prefab and parent had to be known, I added the option to declare them using a delegate with the IObjectResolver

Also have a [branch](https://github.com/AlonTalmi/VContainer/tree/SeparateComponentRegistrationBuilder) that separates the ComponentRegistrationBuilder into separate classes