### PR TITLE
Installer component (like Zenject's MonoInstaller)

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/Unity/InstallerComponents.meta
+++ b/VContainer/Assets/VContainer/Runtime/Unity/InstallerComponents.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 654eab9df1ff4342aa6dc8b27e7daa6b
+timeCreated: 1700142729

--- a/VContainer/Assets/VContainer/Runtime/Unity/InstallerComponents/BuildCallbackInstaller.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/InstallerComponents/BuildCallbackInstaller.cs
@@ -1,0 +1,21 @@
+using UnityEngine;
+
+namespace VContainer.Unity
+{
+    public abstract class BuildCallbackInstaller : InstallerComponent
+    {
+        [SerializeField] bool active = true;
+        
+        protected abstract void OnBuild(IObjectResolver resolver);
+
+        public override void Install(IContainerBuilder builder)
+        {
+            if(!active)
+            {
+                return;
+            }
+
+            builder.RegisterBuildCallback(OnBuild);
+        }
+    }
+}

--- a/VContainer/Assets/VContainer/Runtime/Unity/InstallerComponents/BuildCallbackInstaller.cs.meta
+++ b/VContainer/Assets/VContainer/Runtime/Unity/InstallerComponents/BuildCallbackInstaller.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: a3875f62d1134d4b8c92d6e8581fde24
+timeCreated: 1700142813

--- a/VContainer/Assets/VContainer/Runtime/Unity/InstallerComponents/GetInstallerComponentsGroup.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/InstallerComponents/GetInstallerComponentsGroup.cs
@@ -1,0 +1,39 @@
+using System.Diagnostics;
+using UnityEngine;
+
+namespace VContainer.Unity
+{
+    [DisallowMultipleComponent]
+    public class GetInstallerComponentsGroup : InstallerComponent
+    {
+        [SerializeField] bool active = true;
+        [SerializeField] GameObject target;
+
+        public override void Install(IContainerBuilder builder)
+        {
+            if (!active)
+            {
+                return;
+            }
+
+            if (target == null)
+            {
+                target = gameObject;
+            }
+
+            foreach (var installer in GetComponents<IInstaller>())
+            {
+                if(installer != null && !ReferenceEquals(installer, this))
+                {
+                    installer.Install(builder);
+                }
+            }
+        }
+
+        [Conditional("UNITY_EDITOR")]
+        private void Reset()
+        {
+            target = gameObject;
+        }
+    }
+}

--- a/VContainer/Assets/VContainer/Runtime/Unity/InstallerComponents/GetInstallerComponentsGroup.cs.meta
+++ b/VContainer/Assets/VContainer/Runtime/Unity/InstallerComponents/GetInstallerComponentsGroup.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: a243be69f8ee46de94ccf16eb0abd9e2
+timeCreated: 1700142913

--- a/VContainer/Assets/VContainer/Runtime/Unity/InstallerComponents/InstallerComponent.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/InstallerComponents/InstallerComponent.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+namespace VContainer.Unity
+{
+    public abstract class InstallerComponent : MonoBehaviour, IInstaller
+    {
+        public abstract void Install(IContainerBuilder builder);
+    }
+}

--- a/VContainer/Assets/VContainer/Runtime/Unity/InstallerComponents/InstallerComponent.cs.meta
+++ b/VContainer/Assets/VContainer/Runtime/Unity/InstallerComponents/InstallerComponent.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 9fc1e518cdd7498a91013516ca9c186e
+timeCreated: 1700142748

--- a/VContainer/Assets/VContainer/Runtime/Unity/InstallerComponents/InstallersGroup.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/InstallerComponents/InstallersGroup.cs
@@ -1,0 +1,26 @@
+using UnityEngine;
+
+namespace VContainer.Unity
+{
+    public class InstallersGroup : InstallerComponent
+    {
+        [SerializeField] bool active = true;
+        [SerializeField] InstallerComponent[] installerComponents;
+        
+        public override void Install(IContainerBuilder builder)
+        {
+            if(!active)
+            {
+                return;
+            }
+            
+            foreach (var installer in installerComponents)
+            {
+                if(installer != null && !ReferenceEquals(installer, this))
+                {
+                    installer.Install(builder);
+                }
+            }
+        }
+    }
+}

--- a/VContainer/Assets/VContainer/Runtime/Unity/InstallerComponents/InstallersGroup.cs.meta
+++ b/VContainer/Assets/VContainer/Runtime/Unity/InstallerComponents/InstallersGroup.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 1f9f2fdaf32b42c88b59f9e7c8ad00bc
+timeCreated: 1700143292

--- a/VContainer/Assets/VContainer/Runtime/Unity/InstallerExtensions.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/InstallerExtensions.cs
@@ -20,10 +20,14 @@ namespace VContainer.Unity
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static IContainerBuilder Register(this IContainerBuilder builder, IEnumerable<IInstaller> installers)
         {
-            foreach (var installer in installers)
+            if (installers != null)
             {
-                builder.Register(installer);
+                foreach (var installer in installers)
+                {
+                    builder.Register(installer);
+                }
             }
+            
 
             return builder;
         }

--- a/VContainer/Assets/VContainer/Runtime/Unity/InstallerExtensions.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/InstallerExtensions.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace VContainer.Unity
+{
+    public static class InstallerExtensions
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static IContainerBuilder Register(this IContainerBuilder builder, IInstaller installer)
+        {
+            // ReSharper disable once UseNullPropagation (might be a component)
+            if (installer != null)
+            {
+                installer.Install(builder);
+            }
+            
+            return builder;
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static IContainerBuilder Register(this IContainerBuilder builder, IEnumerable<IInstaller> installers)
+        {
+            foreach (var installer in installers)
+            {
+                builder.Register(installer);
+            }
+
+            return builder;
+        }
+    }
+}

--- a/VContainer/Assets/VContainer/Runtime/Unity/InstallerExtensions.cs.meta
+++ b/VContainer/Assets/VContainer/Runtime/Unity/InstallerExtensions.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 69533112a6494a41bd8cd2ff474baa28
+timeCreated: 1700143896

--- a/VContainer/Assets/VContainer/Runtime/Unity/LifetimeScope.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/LifetimeScope.cs
@@ -55,6 +55,9 @@ namespace VContainer.Unity
 
         [SerializeField]
         protected List<GameObject> autoInjectGameObjects;
+        
+        [SerializeField] 
+        InstallerComponent[] componentInstallers;
 
         static readonly Stack<LifetimeScope> GlobalOverrideParents = new Stack<LifetimeScope>();
         static readonly Stack<IInstaller> GlobalExtraInstallers = new Stack<IInstaller>();
@@ -263,18 +266,14 @@ namespace VContainer.Unity
         {
             Configure(builder);
 
-            foreach (var installer in localExtraInstallers)
-            {
-                installer.Install(builder);
-            }
+            builder.Register(componentInstallers);
+
+            builder.Register(localExtraInstallers);
             localExtraInstallers.Clear();
 
             lock (SyncRoot)
             {
-                foreach (var installer in GlobalExtraInstallers)
-                {
-                    installer.Install(builder);
-                }
+                builder.Register(GlobalExtraInstallers);
             }
 
             builder.RegisterInstance<LifetimeScope>(this).AsSelf();


### PR DESCRIPTION
This is the equivalent of Zenject's MonoInstaller

Also added:
InstallerGroup component that batch multiple installers together (I mostly used it in prefabs, that way I can create a group at the root of the prefab and I don't need to reference the nested installers in the prefab 1 by 1)

GetInstallerComponentsGroup component that batches all installers in GameObject using GetComponent

BuildCallbackInstaller component that is used for actions that run on the Container's build callback