### PR TITLE
System.Object always passed to InjectTypeInfo

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/Internal/TypeAnalyzer.cs
+++ b/VContainer/Assets/VContainer/Runtime/Internal/TypeAnalyzer.cs
@@ -165,6 +165,7 @@ namespace VContainer.Internal
         public static InjectTypeInfo Analyze(Type type)
         {
             var injectConstructor = default(InjectConstructorInfo);
+            var analyzedType = type;
             var typeInfo = type.GetTypeInfo();
 
             // Constructor, single [Inject] constructor -> single most parameters constuctor
@@ -291,7 +292,7 @@ namespace VContainer.Internal
             }
 
             return new InjectTypeInfo(
-                type,
+                analyzedType,
                 injectConstructor,
                 injectMethods,
                 injectFields,


### PR DESCRIPTION
Small bug fix where System.Object always passed to InjectTypeInfo.

This only affected error messages, failed to resolve errors always shown: "Failed to resolve System.Object" instead of the actual type, really annoying when debugging.