### PR TITLE
Added a TryResolve method to IObjectResolver

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/Container.cs
+++ b/VContainer/Assets/VContainer/Runtime/Container.cs
@@ -18,6 +18,15 @@ namespace VContainer
         /// This version of resolve looks for all of scopes
         /// </remarks>
         object Resolve(Type type);
+        
+        /// <summary>
+        /// Try resolve from type
+        /// </summary>
+        /// <remarks>
+        /// This version of resolve looks for all of scopes
+        /// </remarks>
+        /// <returns>Successfully resolved</returns>
+        bool TryResolve(Type type, out object resolved);
 
         /// <summary>
         /// Resolve from meta with registration
@@ -74,6 +83,18 @@ namespace VContainer
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public object Resolve(Type type) => Resolve(FindRegistration(type));
+
+        public bool TryResolve(Type type, out object resolved)
+        {
+            if (TryFindRegistration(type, out var registration))
+            {
+                resolved = Resolve(registration);
+                return true;
+            }
+
+            resolved = default;
+            return false;
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public object Resolve(Registration registration)
@@ -152,16 +173,27 @@ namespace VContainer
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal Registration FindRegistration(Type type)
         {
+            if (TryFindRegistration(type, out var registration))
+                return registration;
+                    
+            throw new VContainerException(type, $"No such registration of type: {type}");
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal bool TryFindRegistration(Type type, out Registration registration)
+        {
             IScopedObjectResolver scope = this;
             while (scope != null)
             {
-                if (scope.TryGetRegistration(type, out var registration))
+                if (scope.TryGetRegistration(type, out registration))
                 {
-                    return registration;
+                    return true;
                 }
                 scope = scope.Parent;
             }
-            throw new VContainerException(type, $"No such registration of type: {type}");
+
+            registration = default;
+            return false;
         }
     }
 
@@ -197,6 +229,19 @@ namespace VContainer
                 return Resolve(registration);
             }
             throw new VContainerException(type, $"No such registration of type: {type}");
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool TryResolve(Type type, out object resolved)
+        {
+            if (registry.TryGet(type, out var registration))
+            {
+                resolved = Resolve(registration);
+                return true;
+            }
+            
+            resolved = default;
+            return false;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/VContainer/Assets/VContainer/Runtime/IObjectResolverExtensions.cs
+++ b/VContainer/Assets/VContainer/Runtime/IObjectResolverExtensions.cs
@@ -9,6 +9,30 @@ namespace VContainer
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static T Resolve<T>(this IObjectResolver resolver) => (T)resolver.Resolve(typeof(T));
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryResolve<T>(this IObjectResolver resolver, out T resolved)
+        {
+            if (resolver.TryResolve(typeof(T), out var r))
+            {
+                resolved = (T)r;
+                return true;
+            }
+
+            resolved = default;
+            return false;
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T ResolveOrDefault<T>(this IObjectResolver resolver, T defaultValue = default)
+        {
+            if (resolver.TryResolve(typeof(T), out var value))
+            {
+                return (T)value;
+            }
+
+            return defaultValue;
+        }
+
         // Using from CodeGen
         [Preserve]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/VContainer/Assets/VContainer/Runtime/Unity/EntryPointDispatcher.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/EntryPointDispatcher.cs
@@ -22,14 +22,7 @@ namespace VContainer.Unity
         {
             PlayerLoopHelper.EnsureInitialized();
 
-            EntryPointExceptionHandler exceptionHandler = null;
-            try
-            {
-                exceptionHandler = container.Resolve<EntryPointExceptionHandler>();
-            }
-            catch (VContainerException ex) when (ex.InvalidType == typeof(EntryPointExceptionHandler))
-            {
-            }
+            EntryPointExceptionHandler exceptionHandler = container.ResolveOrDefault<EntryPointExceptionHandler>();
 
             var initializables = container.Resolve<ContainerLocal<IReadOnlyList<IInitializable>>>().Value;
             for (var i = 0; i < initializables.Count; i++)

--- a/VContainer/Assets/VContainer/Tests/ContainerTest.cs
+++ b/VContainer/Assets/VContainer/Tests/ContainerTest.cs
@@ -518,5 +518,61 @@ namespace VContainer.Tests
             var ctorInjectable = new ServiceA(new NoDependencyServiceA());
             Assert.DoesNotThrow(() => container.Inject(ctorInjectable));
         }
+
+        [Test]
+        public void TryResolveTransient()
+        {
+            var builder = new ContainerBuilder();
+            builder.Register<NoDependencyServiceA>(Lifetime.Transient);
+
+            var container = builder.Build();
+            
+            Assert.That(container.TryResolve<NoDependencyServiceA>(out var obj1), Is.True);
+            Assert.That(container.TryResolve<NoDependencyServiceA>(out var obj2), Is.True);
+            Assert.That(container.TryResolve<NoDependencyServiceB>(out var obj3), Is.False);
+
+            Assert.That(obj1, Is.TypeOf<NoDependencyServiceA>());
+            Assert.That(obj2, Is.TypeOf<NoDependencyServiceA>());
+            Assert.That(obj1, Is.Not.EqualTo(obj2));
+            Assert.That(obj3, Is.Null);
+        }
+        
+        [Test]
+        public void TryResolveSingleton()
+        {
+            var builder = new ContainerBuilder();
+            builder.Register<NoDependencyServiceA>(Lifetime.Singleton);
+
+            var container = builder.Build();
+            Assert.That(container.TryResolve<NoDependencyServiceA>(out var obj1), Is.True);
+            Assert.That(container.TryResolve<NoDependencyServiceA>(out var obj2), Is.True);
+            Assert.That(container.TryResolve<NoDependencyServiceB>(out var obj3), Is.False);
+
+            Assert.That(obj1, Is.TypeOf<NoDependencyServiceA>());
+            Assert.That(obj2, Is.TypeOf<NoDependencyServiceA>());
+            Assert.That(obj1, Is.EqualTo(obj2));
+            Assert.That(obj3, Is.Null);
+        }
+
+        [Test]
+        public void TryResolveScoped()
+        {
+            var builder = new ContainerBuilder();
+            builder.Register<DisposableServiceA>(Lifetime.Scoped);
+
+            var container = builder.Build();
+            Assert.That(container.TryResolve<DisposableServiceA>(out var obj1), Is.True);
+            Assert.That(container.TryResolve<DisposableServiceA>(out var obj2), Is.True);
+            Assert.That(container.TryResolve<DisposableServiceB>(out var obj3), Is.False);
+
+            Assert.That(obj1, Is.TypeOf<DisposableServiceA>());
+            Assert.That(obj2, Is.TypeOf<DisposableServiceA>());
+            Assert.That(obj1, Is.EqualTo(obj2));
+            Assert.That(obj3, Is.Null);
+
+            container.Dispose();
+
+            Assert.That(obj1.Disposed, Is.True);
+        }
     }
 }


### PR DESCRIPTION
I added to IObjectResolver the method:
bool TryResolve(Type type, out object resolved);

And also added 2 extension methods:
TryResolve<T>
T TryResolveOrDefault<T>(T defaultValue = default)

I also implemented it in EntryPointDispatcher because it used try-catch to mimic TryResolve

And added few simple unit test (copied from the default resolve method unit tests)

Also allows to add an Optional inject attribute
