### PR TITLE
Fixed LifetimeScope's Container is null during build callback

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/Unity/LifetimeScope.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/LifetimeScope.cs
@@ -192,8 +192,9 @@ namespace VContainer.Unity
                     ApplicationOrigin = this,
                     Diagnostics = VContainerSettings.DiagnosticsEnabled ? DiagnositcsContext.GetCollector(name) : null,
                 };
+                builder.RegisterBuildCallback(resolver => Container = resolver);
                 InstallTo(builder);
-                Container = builder.Build();
+                builder.Build();
             }
 
             AutoInjectAll();

--- a/VContainer/Assets/VContainer/Runtime/Unity/LifetimeScope.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/LifetimeScope.cs
@@ -178,8 +178,9 @@ namespace VContainer.Unity
                 }
 
                 // ReSharper disable once PossibleNullReferenceException
-                Container = Parent.Container.CreateScope(builder =>
+                Parent.Container.CreateScope(builder =>
                 {
+                    builder.RegisterBuildCallback(SetContainer);
                     builder.ApplicationOrigin = this;
                     builder.Diagnostics = VContainerSettings.DiagnosticsEnabled ? DiagnositcsContext.GetCollector(name) : null;
                     InstallTo(builder);
@@ -192,13 +193,18 @@ namespace VContainer.Unity
                     ApplicationOrigin = this,
                     Diagnostics = VContainerSettings.DiagnosticsEnabled ? DiagnositcsContext.GetCollector(name) : null,
                 };
-                builder.RegisterBuildCallback(resolver => Container = resolver);
+                builder.RegisterBuildCallback(SetContainer);
                 InstallTo(builder);
                 builder.Build();
             }
-
-            AutoInjectAll();
+            
             AwakeWaitingChildren(this);
+        }
+
+        private void SetContainer(IObjectResolver container)
+        {
+            Container = container;
+            AutoInjectAll();
         }
 
         public TScope CreateChild<TScope>(IInstaller installer = null)


### PR DESCRIPTION
If you try and use the LifetimeScope's Container property during the container's build callback (for example when using the Instantiate extension method), the Container is null.

That happens because the Container property is assigned only after the Build method returns (which invokes the build callbacks).

As a quick fix I registered a build callback which registered the container to the Container property (before installing all other installers), that works because the build callback are called FIFO.

Edit: now also fixes AutoInjectGameobjects called after build callbacks which can easily cause duplicate injections if you instantiate an injected GameObject in a build callback