### PR TITLE
Fix PrefabComponentProvider doest recursively inject hierarchy

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/Unity/ComponentRegistrationBuilder.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/ComponentRegistrationBuilder.cs
@@ -83,8 +83,7 @@ namespace VContainer.Unity
             }
             else if (prefab != null)
             {
-                var injector = InjectorCache.GetOrBuild(prefab.GetType());
-                provider = new PrefabComponentProvider(prefab, injector, Parameters, in destination);
+                provider = new PrefabComponentProvider(prefab, Parameters, in destination);
             }
             else
             {

--- a/VContainer/Assets/VContainer/Runtime/Unity/InstanceProviders/PrefabComponentProvider.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/InstanceProviders/PrefabComponentProvider.cs
@@ -1,22 +1,20 @@
 using System.Collections.Generic;
 using UnityEngine;
+using VContainer.Internal;
 
 namespace VContainer.Unity
 {
     sealed class PrefabComponentProvider : IInstanceProvider
     {
-        readonly IInjector injector;
         readonly IReadOnlyList<IInjectParameter> customParameters;
         readonly Component prefab;
         ComponentDestination destination;
 
         public PrefabComponentProvider(
             Component prefab,
-            IInjector injector,
             IReadOnlyList<IInjectParameter> customParameters,
             in ComponentDestination destination)
         {
-            this.injector = injector;
             this.customParameters = customParameters;
             this.prefab = prefab;
             this.destination = destination;
@@ -32,15 +30,15 @@ namespace VContainer.Unity
 
             var parent = destination.GetParent();
             var component = parent != null
-                ? UnityEngine.Object.Instantiate(prefab, parent)
-                : UnityEngine.Object.Instantiate(prefab);
+                ? Object.Instantiate(prefab, parent)
+                : Object.Instantiate(prefab);
 
             if (VContainerSettings.Instance != null && VContainerSettings.Instance.RemoveClonePostfix)
                 component.name = prefab.name;
 
             try
             {
-                injector.Inject(component, resolver, customParameters);
+                resolver.InjectGameObject(component.gameObject, customParameters);
                 destination.ApplyDontDestroyOnLoadIfNeeded(component);
             }
             finally

--- a/VContainer/Assets/VContainer/Runtime/Unity/ObjectResolverUnityExtensions.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/ObjectResolverUnityExtensions.cs
@@ -1,10 +1,12 @@
+using System.Collections.Generic;
 using UnityEngine;
+using VContainer.Internal;
 
 namespace VContainer.Unity
 {
     public static class ObjectResolverUnityExtensions
     {
-        public static void InjectGameObject(this IObjectResolver resolver, GameObject gameObject)
+        public static void InjectGameObject(this IObjectResolver resolver, GameObject gameObject, IReadOnlyList<IInjectParameter> parameters = null)
         {
             void InjectGameObjectRecursive(GameObject current)
             {
@@ -18,7 +20,8 @@ namespace VContainer.Unity
                     {
                         if (monoBehaviour != null)
                         { // Can be null if the MonoBehaviour's type wasn't found (e.g. if it was stripped)
-                            resolver.Inject(monoBehaviour);
+                            var injector = InjectorCache.GetOrBuild(monoBehaviour.GetType());
+                            injector.Inject(monoBehaviour, resolver, parameters);
                         }
                     }
                 }


### PR DESCRIPTION
When instantiating using PrefabComponentProvider, only the registered component is injected and not the entire hierarchy of the prefab.

I changed it so the entire hierarchy is injected, with the parameters provided.

I'm not sure whats a better expected behavior is: 
injecting the parameters to the entire hierarchy or only to the registered component and the rest injecting only using the container