### PR TITLE
Add IObjectResolver.CreateInstance

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/IObjectResolverExtensions.cs
+++ b/VContainer/Assets/VContainer/Runtime/IObjectResolverExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using VContainer.Internal;
 
 namespace VContainer
 {
@@ -33,6 +34,21 @@ namespace VContainer
                 }
             }
             return resolver.Resolve(parameterType);
+        }
+
+        public static object CreateInstance<T>(this IObjectResolver container) =>
+            container.CreateInstance(typeof(T));
+
+        public static object CreateInstance<T>(this IObjectResolver container, IReadOnlyList<IInjectParameter> parameters) =>
+            container.CreateInstance(typeof(T), parameters);
+
+        public static object CreateInstance(this IObjectResolver container, Type type) =>
+            container.CreateInstance(type, null);
+
+        public static object CreateInstance(this IObjectResolver container, Type type, IReadOnlyList<IInjectParameter> parameters)
+        {
+            var injector = InjectorCache.GetOrBuild(type);
+            return injector.CreateInstance(container, parameters);
         }
     }
 }


### PR DESCRIPTION
Add IObjectResolver.CreateInstance().

Note: 
I used to be very negative about introducing this functionality.
One of the reasons I created VContainer was because I wanted a constraint to prevent DI abuse.

The main reason for adding this now is because of the library I'm creating.
`container.Register(c => ...)` I needed to hide the instantiation when registering styles.