### PR TITLE
Add non-generic Register(Type, Type, Lifetime)

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/ContainerBuilderExtensions.cs
+++ b/VContainer/Assets/VContainer/Runtime/ContainerBuilderExtensions.cs
@@ -17,6 +17,14 @@ namespace VContainer
                 : new RegistrationBuilder(type, lifetime));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static RegistrationBuilder Register(
+            this IContainerBuilder builder,
+            Type interfacetType,
+            Type implementationType,
+            Lifetime lifetime) =>
+            builder.Register(implementationType, lifetime).As(interfacetType);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static RegistrationBuilder Register<T>(
             this IContainerBuilder builder,
             Lifetime lifetime) =>


### PR DESCRIPTION
Frankly speaking, two arguments are more modern than `.As()` method chain..

e.g)


```cs
builder.RegisteInstance(LoggerFactory.Create(logging => logging.AddConsole()));
buidler.Register(typeof(ILogger), typeof(Logger), Lifetiem.Singleton);
```