### PR TITLE
Improve IContainerBuilder.Exists()

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ on:
 
 env:
   GIT_TAG: ${{ github.event.inputs.tag }}
-    
+   
 jobs:
   update-version-number:
     uses: ./.github/workflows/update-version-number.yaml

--- a/VContainer/Assets/Tests/ContainerBuilderTest.cs
+++ b/VContainer/Assets/Tests/ContainerBuilderTest.cs
@@ -1,0 +1,46 @@
+using NUnit.Framework;
+
+namespace VContainer.Tests
+{
+    [TestFixture]
+    public class ContainerBuilderTest
+    {
+        [Test]
+        public void Exists()
+        {
+            var builder = new ContainerBuilder();
+            builder.Register<ServiceA>(Lifetime.Singleton)
+                .AsImplementedInterfaces()
+                .AsSelf();
+
+            Assert.That(builder.Exists(typeof(ServiceA)), Is.True);
+            Assert.That(builder.Exists(typeof(I4)), Is.False);
+            Assert.That(builder.Exists(typeof(I4), includeInterfaceTypes: true), Is.True);
+        }
+
+        [Test]
+        public void Exists_FromChild()
+        {
+            var builder = new ContainerBuilder();
+            builder.Register<ServiceA>(Lifetime.Singleton)
+                .AsImplementedInterfaces()
+                .AsSelf();
+
+            var parentScope = builder.Build();
+            var childScope = parentScope.CreateScope(childBuilder =>
+            {
+                childBuilder.Register<ServiceB>(Lifetime.Singleton);
+
+                Assert.That(childBuilder.Exists(typeof(ServiceA)), Is.False);
+                Assert.That(childBuilder.Exists(typeof(I4)), Is.False);
+                Assert.That(childBuilder.Exists(typeof(I4), includeInterfaceTypes: true), Is.False);
+
+                Assert.That(childBuilder.Exists(typeof(ServiceA), findParentScopes: true), Is.True);
+                Assert.That(childBuilder.Exists(typeof(I4), findParentScopes: true), Is.False);
+                Assert.That(childBuilder.Exists(typeof(I4), findParentScopes: true, includeInterfaceTypes: true), Is.True);
+
+                Assert.That(childBuilder.Exists(typeof(ServiceB)), Is.True);
+            });
+       }
+    }
+}

--- a/VContainer/Assets/Tests/ContainerBuilderTest.cs.meta
+++ b/VContainer/Assets/Tests/ContainerBuilderTest.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 78ab12b3d23e4bb6a3c2906056f7821d
+timeCreated: 1709100322

--- a/VContainer/Assets/VContainer/Runtime/Container.cs
+++ b/VContainer/Assets/VContainer/Runtime/Container.cs
@@ -28,13 +28,13 @@ namespace VContainer
         object Resolve(Registration registration);
         IScopedObjectResolver CreateScope(Action<IContainerBuilder> installation = null);
         void Inject(object instance);
+        bool TryGetRegistration(Type type, out Registration registration);
     }
 
     public interface IScopedObjectResolver : IObjectResolver
     {
         IObjectResolver Root { get; }
         IScopedObjectResolver Parent { get; }
-        bool TryGetRegistration(Type type, out Registration registration);
     }
 
     public enum Lifetime
@@ -223,6 +223,11 @@ namespace VContainer
             var injector = InjectorCache.GetOrBuild(instance.GetType());
             injector.Inject(instance, this, null);
         }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool TryGetRegistration(Type type, out Registration registration)
+            => registry.TryGet(type, out registration);
+
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Dispose()


### PR DESCRIPTION
`Exists()` targets only the current scope, but it has proven useful in some cases to examine ancestor scopes.
