### PR TITLE
Fix InjectIgnore not being ignored

### DIFF
--- a/VContainer.SourceGenerator/VContainerIncrementalSourceGenerator.cs
+++ b/VContainer.SourceGenerator/VContainerIncrementalSourceGenerator.cs
@@ -106,7 +106,7 @@ public class VContainerIncrementalSourceGenerator : IIncrementalGenerator
                 var attributeName = attributeSymbol.ContainingType.ToDisplayString();
 
                 // Ignore
-                if (attributeName == "VContainer.InjectIgnore")
+                if (attributeName == "VContainer.InjectIgnoreAttribute")
                     return null;
             }
         }


### PR DESCRIPTION
According to the [document](https://vcontainer.hadashikick.jp/optimization/source-generator#:~:text=If%20you%20want%20to%20exclude%20a%20target%20for%20reasons%20such%20as%20wanting%20to%20suppress%20unnecessary%20code%20generation%2C%20please%20add%20the%20%5BInjectIgnore%5D%20attribute%20to%20the%20type.), the [InjectIgnore] attribute can be used to exclude a target from code generation by SourceGenerator, but it does not appear to be actually excluded. It appears that this was due to the fact that "Attribute" was not appended to the end when validating attributes in the VContainerIncrementalSourceGenerator, so fixed it.