### PR TITLE
Fix Diagnostic window.

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/Diagnostics/DiagnosticsContext.cs
+++ b/VContainer/Assets/VContainer/Runtime/Diagnostics/DiagnosticsContext.cs
@@ -6,19 +6,19 @@ namespace VContainer.Diagnostics
 {
     public static class DiagnositcsContext
     {
-        static readonly Dictionary<string, DiagnosticsCollector> collectors
-            = new Dictionary<string, DiagnosticsCollector>();
+        static readonly Dictionary<int, DiagnosticsCollector> collectors
+            = new Dictionary<int, DiagnosticsCollector>();
 
         public static event Action<IObjectResolver> OnContainerBuilt;
 
-        public static DiagnosticsCollector GetCollector(string name)
+        public static DiagnosticsCollector GetCollector(int instanceId, string name)
         {
             lock (collectors)
             {
-                if (!collectors.TryGetValue(name, out var collector))
+                if (!collectors.TryGetValue(instanceId, out var collector))
                 {
-                    collector = new DiagnosticsCollector(name);
-                    collectors.Add(name, collector);
+                    collector = new DiagnosticsCollector($"${name}/{instanceId}");
+                    collectors.Add(instanceId, collector);
                 }
                 return collector;
             }
@@ -51,6 +51,14 @@ namespace VContainer.Diagnostics
         internal static DiagnosticsInfo FindByRegistration(Registration registration)
         {
             return GetDiagnosticsInfos().FirstOrDefault(x => x.ResolveInfo.Registration == registration);
+        }
+
+        public static void RemoveCollector(int instanceId)
+        {
+            lock (collectors)
+            {
+                collectors.Remove(instanceId);
+            }
         }
     }
 }

--- a/VContainer/Assets/VContainer/Runtime/Unity/LifetimeScope.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/LifetimeScope.cs
@@ -47,6 +47,8 @@ namespace VContainer.Unity
             }
         }
 
+        int instanceId;
+
         [SerializeField]
         public ParentReference parentReference;
 
@@ -65,6 +67,10 @@ namespace VContainer.Unity
             var gameObject = new GameObject("LifetimeScope");
             gameObject.SetActive(false);
             var newScope = gameObject.AddComponent<LifetimeScope>();
+            if (VContainerSettings.DiagnosticsEnabled)
+            {
+                newScope.instanceId = gameObject.GetInstanceID();
+            }
             if (installer != null)
             {
                 newScope.localExtraInstallers.Add(installer);
@@ -168,6 +174,10 @@ namespace VContainer.Unity
             Container?.Dispose();
             Container = null;
             CancelAwake(this);
+            if (VContainerSettings.DiagnosticsEnabled)
+            {
+                DiagnositcsContext.RemoveCollector(instanceId);
+            }
         }
 
         public void Build()
@@ -188,7 +198,7 @@ namespace VContainer.Unity
                 {
                     builder.RegisterBuildCallback(SetContainer);
                     builder.ApplicationOrigin = this;
-                    builder.Diagnostics = VContainerSettings.DiagnosticsEnabled ? DiagnositcsContext.GetCollector(name) : null;
+                    builder.Diagnostics = VContainerSettings.DiagnosticsEnabled ? DiagnositcsContext.GetCollector(instanceId, name) : null;
                     InstallTo(builder);
                 });
             }
@@ -197,7 +207,7 @@ namespace VContainer.Unity
                 var builder = new ContainerBuilder
                 {
                     ApplicationOrigin = this,
-                    Diagnostics = VContainerSettings.DiagnosticsEnabled ? DiagnositcsContext.GetCollector(name) : null,
+                    Diagnostics = VContainerSettings.DiagnosticsEnabled ? DiagnositcsContext.GetCollector(instanceId, name) : null,
                 };
                 builder.RegisterBuildCallback(SetContainer);
                 InstallTo(builder);
@@ -227,6 +237,10 @@ namespace VContainer.Unity
                 childGameObject.transform.SetParent(transform, false);
             }
             var child = childGameObject.AddComponent<TScope>();
+            if (VContainerSettings.DiagnosticsEnabled)
+            {
+                child.instanceId = childGameObject.GetInstanceID();
+            }
             if (installer != null)
             {
                 child.localExtraInstallers.Add(installer);


### PR DESCRIPTION
Hi @hadashiA ! 
I have the problem described here https://github.com/hadashiA/VContainer/issues/621. I've been looking at the logic for collecting diagnostics and was going to suggest the simple solution, to check the unique scopes with GameObject instanceId.
There is a small problem from using Lookup when building a window. For this I had to add an instanceId to the name of the scope to output to the window.

Also wanted to suggest to add cleaning the scopes from the diagnostics after Dispose/Destroy.

If you have any other suggestions I can fix this solution.