### PR TITLE
Added test and fix for when a game object throws during instantiation

### DIFF
--- a/VContainer/Assets/Tests/Unity/Fixtures/CrashingSampleMonoBehaviour.cs
+++ b/VContainer/Assets/Tests/Unity/Fixtures/CrashingSampleMonoBehaviour.cs
@@ -1,0 +1,29 @@
+using System;
+using UnityEngine;
+
+namespace VContainer.Tests.Unity
+{
+
+    public sealed class CrashingSampleMonoBehaviour : MonoBehaviour, IComponent
+    {
+        public ServiceA ServiceA;
+        public ServiceA ServiceAInAwake;
+        public bool StartCalled;
+        public int UpdateCalls;
+
+        void Start() => StartCalled = true;
+        void Update() => UpdateCalls += 1;
+
+        void Awake()
+        {
+            ServiceAInAwake = ServiceA;
+        }
+
+        [Inject]
+        public void Construct(ServiceA serviceA)
+        {
+            ServiceA = serviceA;
+            throw new Exception("Something broke during construct");
+        }
+    }
+}

--- a/VContainer/Assets/Tests/Unity/Fixtures/CrashingSampleMonoBehaviour.cs.meta
+++ b/VContainer/Assets/Tests/Unity/Fixtures/CrashingSampleMonoBehaviour.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 02481ae92e864544bd3bb0f9df8d099d
+timeCreated: 1713431065

--- a/VContainer/Assets/Tests/Unity/UnityObjectResolverTest.cs
+++ b/VContainer/Assets/Tests/Unity/UnityObjectResolverTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reflection;
 using NUnit.Framework;
 using UnityEngine;
 using VContainer.Unity;
@@ -140,6 +141,22 @@ namespace VContainer.Tests.Unity
                 Assert.That(instance.ServiceAInAwake, Is.InstanceOf<ServiceA>());
                 Assert.That(instance.ServiceA, Is.InstanceOf<ServiceA>());
             }
+        }
+        
+        [Test]
+        public void WhenFailingDuringInstantiateGameObject_TheGameObjectIsStillEnabled()
+        {
+            var builder = new ContainerBuilder();
+            builder.Register<ServiceA>(Lifetime.Singleton);
+            var container = builder.Build();
+
+            var parent = new GameObject("Parent");
+            GameObject original = new GameObject("Original");
+            original.AddComponent<CrashingSampleMonoBehaviour>();
+
+            Assert.Catch(() => container.Instantiate(original, parent.transform));
+            
+            Assert.That(original.gameObject.activeSelf, Is.True);
         }
 
         [Test]

--- a/VContainer/Assets/VContainer/Runtime/Unity/ObjectResolverUnityExtensions.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/ObjectResolverUnityExtensions.cs
@@ -183,14 +183,18 @@ namespace VContainer.Unity
             var wasActive = prefab.activeSelf;
             prefab.SetActive(false);
 
-            var instance = UnityEngine.Object.Instantiate(prefab, parent, worldPositionStays);
-            SetName(instance, prefab);
-
-            resolver.InjectGameObject(instance);
-
-            prefab.SetActive(wasActive);
-            instance.SetActive(wasActive);
-
+            GameObject instance = null;
+            try
+            {
+                instance = UnityEngine.Object.Instantiate(prefab, parent, worldPositionStays);
+                SetName(instance, prefab);
+                resolver.InjectGameObject(instance);
+            }
+            finally
+            {
+                prefab.SetActive(wasActive);
+                instance?.SetActive(wasActive);    
+            }
             return instance;
         }
 


### PR DESCRIPTION
In our game we sometimes have problems during the init of a game mode. When this happens, we have a transition game object that is disabled and occasionally that change gets committed. Similar try finally guards other code paths but not the one we were using.
This fixes our case but maybe all paths should have this construct?