### PR TITLE
Make IAsyncStartable available on Unity 2021.3 using System.Threading.Tasks.Task

### DIFF
--- a/VContainer/Assets/Tests/Unity/EntryPointTest.cs
+++ b/VContainer/Assets/Tests/Unity/EntryPointTest.cs
@@ -227,6 +227,6 @@ namespace VContainer.Tests.Unity
 
             Assert.That(handled, Is.EqualTo(1));
         }
-    }
 #endif
+    }
 }

--- a/VContainer/Assets/Tests/Unity/EntryPointTest.cs
+++ b/VContainer/Assets/Tests/Unity/EntryPointTest.cs
@@ -209,5 +209,24 @@ namespace VContainer.Tests.Unity
             Assert.That(childEntryPoint.InitializeCalled, Is.EqualTo(1));
             Assert.That(childEntryPoint.StartCalled, Is.EqualTo(1));
         }
+
+#if UNITY_2023_1_OR_NEWER
+        [UnityTest]
+        public IEnumerator AsyncStartableExceptionHandler()
+        {
+            var handled = 0;
+
+            LifetimeScope.Create(builder =>
+            {
+                builder.RegisterEntryPoint<AsyncStartableThrowable>();
+                builder.RegisterEntryPointExceptionHandler(_ => { handled += 1; });
+            });
+
+            yield return null;
+            yield return null;
+
+            Assert.That(handled, Is.EqualTo(1));
+        }
     }
+#endif
 }

--- a/VContainer/Assets/Tests/Unity/EntryPointTest.cs
+++ b/VContainer/Assets/Tests/Unity/EntryPointTest.cs
@@ -210,7 +210,7 @@ namespace VContainer.Tests.Unity
             Assert.That(childEntryPoint.StartCalled, Is.EqualTo(1));
         }
 
-#if UNITY_2023_1_OR_NEWER
+#if UNITY_2021_3_OR_NEWER
         [UnityTest]
         public IEnumerator AsyncStartableExceptionHandler()
         {

--- a/VContainer/Assets/Tests/Unity/Fixtures/SampleEntryPoint.cs
+++ b/VContainer/Assets/Tests/Unity/Fixtures/SampleEntryPoint.cs
@@ -1,6 +1,10 @@
 using System.Threading;
-using UnityEngine;
 using VContainer.Unity;
+#if UNITY_2023_1_OR_NEWER
+using UnityEngine;
+#else
+using Awaitable = System.Threading.Tasks.Task;
+#endif
 
 namespace VContainer.Tests.Unity
 {
@@ -154,7 +158,7 @@ namespace VContainer.Tests.Unity
         }
     }
 
-#if UNITY_2023_1_OR_NEWER
+#if UNITY_2021_3_OR_NEWER
     public class AsyncStartableThrowable : IAsyncStartable
     {
         public Awaitable StartAsync(CancellationToken cancellation)

--- a/VContainer/Assets/Tests/Unity/Fixtures/SampleEntryPoint.cs
+++ b/VContainer/Assets/Tests/Unity/Fixtures/SampleEntryPoint.cs
@@ -1,3 +1,5 @@
+using System.Threading;
+using UnityEngine;
 using VContainer.Unity;
 
 namespace VContainer.Tests.Unity
@@ -151,4 +153,12 @@ namespace VContainer.Tests.Unity
             throw new System.NotImplementedException();
         }
     }
+
+#if UNITY_2023_1_OR_NEWER
+    public class AsyncStartableThrowable : IAsyncStartable
+    {
+        public Awaitable StartAsync(CancellationToken cancellation)
+            => throw new System.NotImplementedException();
+    }
+#endif
 }

--- a/VContainer/Assets/VContainer/Runtime/Annotations/AwaitableExtensions.cs
+++ b/VContainer/Assets/VContainer/Runtime/Annotations/AwaitableExtensions.cs
@@ -1,0 +1,26 @@
+#if UNITY_2023_1_OR_NEWER
+using System;
+using UnityEngine;
+
+namespace VContainer.Unity
+{
+    internal static class AwaitableExtensions
+    {
+        public static async Awaitable Forget(this Awaitable awaitable,
+            EntryPointExceptionHandler exceptionHandler = null)
+        {
+            try
+            {
+                await awaitable;
+            }
+            catch (Exception ex)
+            {
+                if (exceptionHandler != null)
+                    exceptionHandler.Publish(ex);
+                else
+                    throw;
+            }
+        }
+    }
+}
+#endif

--- a/VContainer/Assets/VContainer/Runtime/Annotations/AwaitableExtensions.cs
+++ b/VContainer/Assets/VContainer/Runtime/Annotations/AwaitableExtensions.cs
@@ -1,6 +1,11 @@
-#if UNITY_2023_1_OR_NEWER
+#if UNITY_2021_3_OR_NEWER
 using System;
+#if UNITY_2023_1_OR_NEWER
 using UnityEngine;
+#else
+using Awaitable = System.Threading.Tasks.Task;
+#endif
+
 
 namespace VContainer.Unity
 {

--- a/VContainer/Assets/VContainer/Runtime/Annotations/AwaitableExtensions.cs
+++ b/VContainer/Assets/VContainer/Runtime/Annotations/AwaitableExtensions.cs
@@ -1,3 +1,26 @@
+//
+// Copyright (c) 2024 left (https://github.com/left-/)
+// Copyright (c) 2020 hadashiA
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
 #if UNITY_2021_3_OR_NEWER
 using System;
 #if UNITY_2023_1_OR_NEWER
@@ -5,7 +28,6 @@ using UnityEngine;
 #else
 using Awaitable = System.Threading.Tasks.Task;
 #endif
-
 
 namespace VContainer.Unity
 {

--- a/VContainer/Assets/VContainer/Runtime/Annotations/AwaitableExtensions.cs.meta
+++ b/VContainer/Assets/VContainer/Runtime/Annotations/AwaitableExtensions.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 9cbf97ce69c64b73a70d6514c63fba00
+timeCreated: 1717651770

--- a/VContainer/Assets/VContainer/Runtime/Annotations/IAsyncStartable.cs
+++ b/VContainer/Assets/VContainer/Runtime/Annotations/IAsyncStartable.cs
@@ -1,18 +1,8 @@
-#if VCONTAINER_UNITASK_INTEGRATION
-using System.Threading;
-using Cysharp.Threading.Tasks;
-
-namespace VContainer.Unity
-{
-    public interface IAsyncStartable
-    {
-        UniTask StartAsync(CancellationToken cancellation);
-    }
-}
-#elif UNITY_2021_3_OR_NEWER
 using System.Threading;
 #if UNITY_2023_1_OR_NEWER
 using UnityEngine;
+#elif VCONTAINER_UNITASK_INTEGRATION
+using Awaitable = Cysharp.Threading.Tasks.UniTask;
 #else
 using Awaitable = System.Threading.Tasks.Task;
 #endif
@@ -24,4 +14,3 @@ namespace VContainer.Unity
         Awaitable StartAsync(CancellationToken cancellation = default);
     }
 }
-#endif

--- a/VContainer/Assets/VContainer/Runtime/Annotations/IAsyncStartable.cs
+++ b/VContainer/Assets/VContainer/Runtime/Annotations/IAsyncStartable.cs
@@ -9,9 +9,13 @@ namespace VContainer.Unity
         UniTask StartAsync(CancellationToken cancellation);
     }
 }
-#elif UNITY_2023_1_OR_NEWER
+#elif UNITY_2021_3_OR_NEWER
 using System.Threading;
+#if UNITY_2023_1_OR_NEWER
 using UnityEngine;
+#else
+using Awaitable = System.Threading.Tasks.Task;
+#endif
 
 namespace VContainer.Unity
 {

--- a/VContainer/Assets/VContainer/Runtime/Annotations/IAsyncStartable.cs
+++ b/VContainer/Assets/VContainer/Runtime/Annotations/IAsyncStartable.cs
@@ -10,7 +10,6 @@ namespace VContainer.Unity
     }
 }
 #elif UNITY_2023_1_OR_NEWER
-using System;
 using System.Threading;
 using UnityEngine;
 
@@ -19,28 +18,6 @@ namespace VContainer.Unity
     public interface IAsyncStartable
     {
         Awaitable StartAsync(CancellationToken cancellation = default);
-    }
-
-    static class AwaitableHelper
-    {
-        public static async Awaitable Forget(Awaitable awaitable, EntryPointExceptionHandler exceptionHandler)
-        {
-            try
-            {
-                await awaitable;
-            }
-            catch (Exception ex)
-            {
-                if (exceptionHandler != null)
-                {
-                    exceptionHandler.Publish(ex);
-                }
-                else
-                {
-                    throw;
-                }
-            }
-        }
     }
 }
 #endif

--- a/VContainer/Assets/VContainer/Runtime/Annotations/IAsyncStartable.cs
+++ b/VContainer/Assets/VContainer/Runtime/Annotations/IAsyncStartable.cs
@@ -18,7 +18,7 @@ namespace VContainer.Unity
 {
     public interface IAsyncStartable
     {
-        Awaitable StartAsync(CancellationToken cancellation);
+        Awaitable StartAsync(CancellationToken cancellation = default);
     }
 
     static class AwaitableHelper

--- a/VContainer/Assets/VContainer/Runtime/Unity/EntryPointDispatcher.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/EntryPointDispatcher.cs
@@ -120,7 +120,7 @@ namespace VContainer.Unity
                 PlayerLoopHelper.Dispatch(PlayerLoopTiming.PostLateUpdate, loopItem);
             }
 
-#if VCONTAINER_UNITASK_INTEGRATION
+#if VCONTAINER_UNITASK_INTEGRATION || UNITY_2023_1_OR_NEWER
             var asyncStartables = container.Resolve<ContainerLocal<IReadOnlyList<IAsyncStartable>>>().Value;
             if (asyncStartables.Count > 0)
             {

--- a/VContainer/Assets/VContainer/Runtime/Unity/EntryPointDispatcher.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/EntryPointDispatcher.cs
@@ -120,7 +120,7 @@ namespace VContainer.Unity
                 PlayerLoopHelper.Dispatch(PlayerLoopTiming.PostLateUpdate, loopItem);
             }
 
-#if VCONTAINER_UNITASK_INTEGRATION || UNITY_2023_1_OR_NEWER
+#if VCONTAINER_UNITASK_INTEGRATION || UNITY_2021_3_OR_NEWER
             var asyncStartables = container.Resolve<ContainerLocal<IReadOnlyList<IAsyncStartable>>>().Value;
             if (asyncStartables.Count > 0)
             {

--- a/VContainer/Assets/VContainer/Runtime/Unity/LifetimeScope.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/LifetimeScope.cs
@@ -114,7 +114,7 @@ namespace VContainer.Unity
 
         static LifetimeScope Find(Type type)
         {
-#if UNITY_2020_4_OR_NEWER || UNITY_2021_4_OR_NEWER || UNITY_2022_3_OR_NEWER || UNITY_2023_1_OR_NEWER
+#if UNITY_2020_4_OR_NEWER || UNITY_2021_4_OR_NEWER || UNITY_2022_3_OR_NEWER || UNITY_2021_3_OR_NEWER
             return (LifetimeScope)FindAnyObjectByType(type);
 #else
             return (LifetimeScope)FindObjectOfType(type);

--- a/VContainer/Assets/VContainer/Runtime/Unity/PlayerLoopItem.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/PlayerLoopItem.cs
@@ -287,7 +287,7 @@ namespace VContainer.Unity
         public void Dispose() => disposed = true;
     }
 
-#if VCONTAINER_UNITASK_INTEGRATION || UNITY_2023_1_OR_NEWER
+#if VCONTAINER_UNITASK_INTEGRATION || UNITY_2021_3_OR_NEWER
     sealed class AsyncStartableLoopItem : IPlayerLoopItem, IDisposable
     {
         readonly IEnumerable<IAsyncStartable> entries;

--- a/VContainer/Assets/VContainer/Runtime/Unity/PlayerLoopItem.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/PlayerLoopItem.cs
@@ -315,18 +315,18 @@ namespace VContainer.Unity
                 else
                     task.Forget();
 #else
-                ExecuteAsyncStartable(x);
+                InvokeStartAsync(x);
 #endif
             }
             return false;
         }
 
-        private void ExecuteAsyncStartable(IAsyncStartable x)
+        private void InvokeStartAsync(IAsyncStartable x)
         {
             try
             {
                 var task = x.StartAsync(cts.Token);
-                var _ = AwaitableHelper.Forget(task, exceptionHandler);
+                _ = task.Forget(exceptionHandler);
             }
             catch (Exception ex)
             {

--- a/VContainer/Assets/VContainer/Runtime/VContainer.asmdef
+++ b/VContainer/Assets/VContainer/Runtime/VContainer.asmdef
@@ -1,6 +1,6 @@
 {
     "name": "VContainer",
-    "rootNamespace": "",
+    "rootNamespace": "VContainer",
     "references": [
         "Unity.Collections",
         "Unity.Entities",


### PR DESCRIPTION
This PR changes IAsyncStartable to support UniTask, .NET Task, and Awaitable.

It makes async startable available to projects running on current Unity LTS that cannot use UniTask (e.g., due to legacy reasons).

It also adds a new entry point test to IAsyncStartable and fixes a bug in which tasks throw exceptions before executing a continuation.