### PR TITLE
Fix for usage of ListBuffer to be properly released

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/Unity/InstanceProviders/FindComponentProvider.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/InstanceProviders/FindComponentProvider.cs
@@ -40,12 +40,14 @@ namespace VContainer.Unity
             }
             else if (scene.IsValid())
             {
-                var gameObjectBuffer = UnityEngineObjectListBuffer<GameObject>.Get();
-                scene.GetRootGameObjects(gameObjectBuffer);
-                foreach (var gameObject in gameObjectBuffer)
+                using (UnityEngineObjectListBuffer<GameObject>.Get(out var gameObjectBuffer))
                 {
-                    component = gameObject.GetComponentInChildren(componentType, true);
-                    if (component != null) break;
+                    scene.GetRootGameObjects(gameObjectBuffer);
+                    foreach (var gameObject in gameObjectBuffer)
+                    {
+                        component = gameObject.GetComponentInChildren(componentType, true);
+                        if (component != null) break;
+                    }
                 }
                 if (component == null)
                 {

--- a/VContainer/Assets/VContainer/Runtime/Unity/LifetimeScope.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/LifetimeScope.cs
@@ -101,13 +101,15 @@ namespace VContainer.Unity
 
         static LifetimeScope Find(Type type, Scene scene)
         {
-            var buffer = UnityEngineObjectListBuffer<GameObject>.Get();
-            scene.GetRootGameObjects(buffer);
-            foreach (var gameObject in buffer)
+            using (UnityEngineObjectListBuffer<GameObject>.Get(out var buffer))
             {
-                var found = gameObject.GetComponentInChildren(type) as LifetimeScope;
-                if (found != null)
-                    return found;
+                scene.GetRootGameObjects(buffer);
+                foreach (var gameObject in buffer)
+                {
+                    var found = gameObject.GetComponentInChildren(type) as LifetimeScope;
+                    if (found != null)
+                        return found;
+                }
             }
             return null;
         }


### PR DESCRIPTION
When checking the VContainer implementation I've found that ListBuffer is used incorrectly in two instances. The list is being provided by the pool but it's never released to it. I've made a quick fix using BufferScope to properly dispose of and release the list back to the pool.

I've done a test with `LifetimeScope:Find<T>(Scene scene)` and for 1000 calls only one list was created as expected.
