### PR TITLE
fix source generator for public property private setter

### DIFF
--- a/VContainer.SourceGenerator/Emitter.cs
+++ b/VContainer.SourceGenerator/Emitter.cs
@@ -132,7 +132,7 @@ static class Emitter
             // verify property
             foreach (var propSymbol in typeMeta.InjectProperties)
             {
-                if (propSymbol.SetMethod == null || !propSymbol.SetMethod.CanBeCallFromInternal())
+                if (propSymbol.SetMethod == null || !propSymbol.SetMethod.IsInitOnly || !propSymbol.SetMethod.CanBeCallFromInternal())
                 {
                     context.ReportDiagnostic(Diagnostic.Create(
                         DiagnosticDescriptors.PrivatePropertyNotSupported,

--- a/VContainer.SourceGenerator/Emitter.cs
+++ b/VContainer.SourceGenerator/Emitter.cs
@@ -132,7 +132,7 @@ static class Emitter
             // verify property
             foreach (var propSymbol in typeMeta.InjectProperties)
             {
-                if (!propSymbol.CanBeCallFromInternal())
+                if (propSymbol.SetMethod == null || !propSymbol.SetMethod.CanBeCallFromInternal())
                 {
                     context.ReportDiagnostic(Diagnostic.Create(
                         DiagnosticDescriptors.PrivatePropertyNotSupported,


### PR DESCRIPTION
Fixed an issue where the source generator would generate code that accesses inaccessible property setters.