### PR TITLE
feature: Add protected FindParent method

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/Unity/LifetimeScope.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/LifetimeScope.cs
@@ -307,12 +307,24 @@ namespace VContainer.Unity
             EntryPointsBuilder.EnsureDispatcherRegistered(builder);
         }
 
+        protected virtual LifetimeScope FindParent() => null;
+
         LifetimeScope GetRuntimeParent()
         {
             if (IsRoot) return null;
 
             if (parentReference.Object != null)
                 return parentReference.Object;
+            
+            // Find via implementation
+            var implParent = FindParent();
+            if (implParent != null)
+            {
+                if (parentReference.Type != null && parentReference.Type != implParent.GetType()) {
+                    UnityEngine.Debug.LogWarning($"FindParent returned {implParent.GetType()} but parent reference type is {parentReference.Type}. This may be unintentional.");
+                }
+                return implParent;
+            }
 
             // Find in scene via type
             if (parentReference.Type != null && parentReference.Type != GetType())


### PR DESCRIPTION
This will allow implementors the opportunity to override runtime Find behavior. This is particularly useful for projects that implement multiple potential parent scopes and need a way to disambiguate them.

For example, some child scopes might want to specifically find ancestors up their transform tree:

```csharp
public class ParentedLifetimeScope : LifetimeScope {
    protected override LifetimeScope FindParent() {
        LifetimeScope[] allScopes = FindObjectsByType(type, FindObjectsSortMode.None).Cast<LifetimeScope>().ToArray();
        return allScopes.First(x => IsAncestor(x.gameObject));
    }

    public bool IsAncestor(GameObject target) {
            var parent = this.transform.parent;
            while (parent != null)
            {
                if (parent == target.transform)
                {
                    return true;
                }

                parent = parent.parent;
            }

            return false;
        } 
}
```

All unit tests pass with this change and because the implementation is a virtual method that defaults to the previous functionality, current behavior is unchanged.