### PR TITLE
Add non-generic RegisterInstance overload

### DIFF
--- a/VContainer/Assets/VContainer/Editor/ParentReferencePropertyDrawer.cs
+++ b/VContainer/Assets/VContainer/Editor/ParentReferencePropertyDrawer.cs
@@ -14,6 +14,7 @@ namespace VContainer.Editor
         {
             return new List<string> { "None" }
                 .Concat(TypeCache.GetTypesDerivedFrom<LifetimeScope>()
+                    .Where(x => !x.IsAbstract)
                     .Select(type => type.FullName))
                 .ToArray();
         }

--- a/VContainer/Assets/VContainer/Runtime/ContainerBuilderExtensions.cs
+++ b/VContainer/Assets/VContainer/Runtime/ContainerBuilderExtensions.cs
@@ -57,7 +57,14 @@ namespace VContainer
             Func<IObjectResolver, TInterface> implementationConfiguration,
             Lifetime lifetime)
             => builder.Register(new FuncRegistrationBuilder(container => implementationConfiguration(container), typeof(TInterface), lifetime));
-
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static RegistrationBuilder RegisterInstance(
+            this IContainerBuilder builder,
+            object instance,
+            Type implementationType)
+            => builder.Register(new InstanceRegistrationBuilder(instance)).As(implementationType);
+        
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static RegistrationBuilder RegisterInstance<TInterface>(
             this IContainerBuilder builder,


### PR DESCRIPTION
This pull request simply adds a new overload for RegisterInstance that allows the caller to specify the type of the instance as a parameter without generics. This matches the behaviour of other registration overloads that allow passing the type at runtime.

This behaviour is useful when registering multiple items from a list when we can't know at compile-time what types may appear in the list. For instance, in my game each game state can register arbitrary ScriptableObjects that are assigned in the inspector:
```csharp
foreach (var data in m_GlobalData)
 {
    builder.RegisterInstance(data, data.GetType());
 }
```

The implementation is nearly identical to the generic version but uses the method parameter `implementationType` instead of a generic type parameter in the `As()` call.