### PR TITLE
Fix Diagnostics tree view Type column overlap

### DIFF
--- a/VContainer/Assets/VContainer/Editor/Diagnostics/VContainerDiagnosticsTreeView.cs
+++ b/VContainer/Assets/VContainer/Editor/Diagnostics/VContainerDiagnosticsTreeView.cs
@@ -212,10 +212,16 @@ namespace VContainer.Editor.Diagnostics
 
         protected override void RowGUI(RowGUIArgs args)
         {
+            const string indentStr = "     ";
+            const int scopeIndents = 1;
+
             var item = args.item as DiagnosticsInfoTreeViewItem;
             if (item is null)
             {
-                base.RowGUI(args);
+                // base.RowGUI(args);
+                var labelStyle = args.selected ? EditorStyles.whiteLabel : EditorStyles.label;
+                labelStyle.alignment = TextAnchor.MiddleLeft;
+                EditorGUI.LabelField(args.GetCellRect(0), RepeatStrBuilder(indentStr, scopeIndents) + args.label, labelStyle);
                 return;
             }
 
@@ -231,7 +237,8 @@ namespace VContainer.Editor.Diagnostics
                 switch (columnIndex)
                 {
                     case 0:
-                        base.RowGUI(args);
+                        // base.RowGUI(args);
+                        EditorGUI.LabelField(cellRect, RepeatStrBuilder(indentStr, item.depth + scopeIndents) + item.TypeSummary, labelStyle);
                         break;
                     case 1:
                         EditorGUI.LabelField(cellRect, item.ContractTypesSummary, labelStyle);
@@ -254,6 +261,15 @@ namespace VContainer.Editor.Diagnostics
                     default:
                         throw new ArgumentOutOfRangeException(nameof(columnIndex), columnIndex, null);
                 }
+            }
+
+            return;
+
+            static string RepeatStrBuilder(string text, int n)
+            {
+                return new System.Text.StringBuilder(text.Length * n)
+                    .Insert(0, text, n)
+                    .ToString();
             }
         }
 


### PR DESCRIPTION
Fixes an issue with the Type column in the Diagnostics window overlapping with other columns and not being styled correctly.

As seen here (from Unity's Boss Room Demo):
![before](https://github.com/user-attachments/assets/40de2c05-d8ae-47a5-891f-b37115886f11)

A hacky fix, but does not require modifying Unity code. Commented out `base.RowGUI(args);` in case there is a better way.
Result:
![after](https://github.com/user-attachments/assets/94a96926-93c7-454f-bbe6-50936eb1435f)