### PR TITLE
Add an overload method RegisterEntryPoint

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/Unity/ContainerBuilderUnityExtensions.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/ContainerBuilderUnityExtensions.cs
@@ -106,6 +106,16 @@ namespace VContainer.Unity
             return builder.Register<T>(lifetime).AsImplementedInterfaces();
         }
 
+        public static RegistrationBuilder RegisterEntryPoint<TInterface>(
+            this IContainerBuilder builder,
+            Func<IObjectResolver, TInterface> implementationConfiguration,
+            Lifetime lifetime)
+        {
+            EntryPointsBuilder.EnsureDispatcherRegistered(builder);
+            return builder.Register(new FuncRegistrationBuilder(container => implementationConfiguration(container),
+                typeof(TInterface), lifetime)).AsImplementedInterfaces();
+        }
+
         public static void RegisterEntryPointExceptionHandler(
             this IContainerBuilder builder,
             Action<Exception> exceptionHandler)


### PR DESCRIPTION
This method allows for registering an entry point by providing an implementation configuration function, ensuring the correct interfaces are registered with the container.