### PR TITLE
Fix Diagnostics window Type column overflow + InstanceTreeView exception

### DIFF
--- a/VContainer/Assets/VContainer/Editor/Diagnostics/VContainerDiagnosticsTreeView.cs
+++ b/VContainer/Assets/VContainer/Editor/Diagnostics/VContainerDiagnosticsTreeView.cs
@@ -215,7 +215,13 @@ namespace VContainer.Editor.Diagnostics
             var item = args.item as DiagnosticsInfoTreeViewItem;
             if (item is null)
             {
-                base.RowGUI(args);
+                var cellRect = args.GetCellRect(0);
+                GUI.BeginGroup(cellRect);
+                {
+                    args.rowRect = new Rect(0, 0, cellRect.width, cellRect.height);
+                    base.RowGUI(args);
+                }
+                GUI.EndGroup();
                 return;
             }
 
@@ -231,7 +237,12 @@ namespace VContainer.Editor.Diagnostics
                 switch (columnIndex)
                 {
                     case 0:
-                        base.RowGUI(args);
+                        GUI.BeginGroup(cellRect);
+                        {
+                            args.rowRect = new Rect(0, 0, cellRect.width, cellRect.height);
+                            base.RowGUI(args);
+                        }
+                        GUI.EndGroup();
                         break;
                     case 1:
                         EditorGUI.LabelField(cellRect, item.ContractTypesSummary, labelStyle);

--- a/VContainer/Assets/VContainer/Editor/Diagnostics/VContainerInstanceTreeView.cs
+++ b/VContainer/Assets/VContainer/Editor/Diagnostics/VContainerInstanceTreeView.cs
@@ -68,9 +68,17 @@ namespace VContainer.Editor.Diagnostics
 
                 try
                 {
-                    var value = prop.GetValue(instance);
-                    var displayName = $"{prop.Name} = ({TypeNameHelper.GetTypeAlias(prop.PropertyType)}) {Stringify(value)}";
-                    parent.AddChild(new TreeViewItem(NextId(), parent.depth + 1, displayName));
+                    if (prop.CanRead)
+                    {
+                        var value = prop.GetValue(instance);
+                        var displayName = $"{prop.Name} = ({TypeNameHelper.GetTypeAlias(prop.PropertyType)}) {Stringify(value)}";
+                        parent.AddChild(new TreeViewItem(NextId(), parent.depth + 1, displayName));
+                    }
+                    else
+                    {
+                        var displayName = $"{prop.Name} = (write-only {TypeNameHelper.GetTypeAlias(prop.PropertyType)})";
+                        parent.AddChild(new TreeViewItem(NextId(), parent.depth + 1, displayName));
+                    }
                 }
                 catch (MissingReferenceException)
                 {


### PR DESCRIPTION
- Fix Diagnostics window Type column contents overflowing.
Before:
![before](https://github.com/user-attachments/assets/80106d75-b80d-442a-9411-824f38339206)
After:
![after](https://github.com/user-attachments/assets/ffb2e82a-1dab-41fa-a61f-c4494c58f51e)

- Fix `VContainerInstanceTreeView` calling `GetValue` on properties without a getter.