### PR TITLE
Fix so that “DontDestroyOnLoad” takes precedence when there are multiple LifetimeScope of the same class.

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/Unity/LifetimeScope.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/LifetimeScope.cs
@@ -118,10 +118,22 @@ namespace VContainer.Unity
         static LifetimeScope Find(Type type)
         {
 #if UNITY_2022_1_OR_NEWER
-            return (LifetimeScope)FindAnyObjectByType(type);
+            var objects = FindObjectsByType(type, FindObjectsInactive.Exclude, FindObjectsSortMode.None);
 #else
-            return (LifetimeScope)FindObjectOfType(type);
+            var objects = FindObjectsOfType(type);
 #endif
+            if (objects.Length > 1)
+            {
+                foreach (var obj in objects)
+                {
+                    if (obj is LifetimeScope lifetimeScope
+                        && lifetimeScope.gameObject.scene.name == "DontDestroyOnLoad")
+                    {
+                        return lifetimeScope;
+                    }
+                }
+            }
+            return (LifetimeScope)objects[0];
         }
 
         public IObjectResolver Container { get; private set; }


### PR DESCRIPTION
## What happened?

When I use `FindAnyObjectByType` in `LifetimeScope.Find`, the order of acquisition is not guaranteed and sometimes `Configure` is not called. Also, I am using a singleton LifetimeScope, which is a rare case, but I would appreciate your consideration.

https://github.com/hadashiA/VContainer/blob/583d0211d2ae0a70b689d6fb08b506e79ea8ad70/VContainer/Assets/VContainer/Runtime/Unity/LifetimeScope.cs#L118-L125

## Reproducing the problem

- Unity uses 2022.1 or higher
- Create a singleton LifetimeScope
- Create a LifetimeScope with a singleton LifetimeScope as Parent
- Attach the created script to a different game object and place it in the scene
- Create a script that repeats the scene transitions and attach it to the appropriate object.
- Wait until `Assert` of `ReloadTestLifetimeScope` fails.

<img width="666" alt="src" src="https://github.com/user-attachments/assets/64f8edea-29b0-47ae-b25e-9234b5b4cbe5">

## Code

#### DontDestroyOnLoadLifetimeScope.cs
singleton LifetimeScope
```c#
using UnityEngine.Assertions;
using VContainer;
using VContainer.Unity;

public sealed class DontDestroyOnLoadLifetimeScope : LifetimeScope
{
    static DontDestroyOnLoadLifetimeScope s_instance;
    
    bool _isCalled;
    
    protected override void Awake()
    {
        if (s_instance == null)
        {
            base.Awake();
            s_instance = this;
            DontDestroyOnLoad(gameObject);
        }
        else if(s_instance != this)
        {
            Destroy(gameObject);
        }
    }
    
    void Start() => Assert.IsTrue(_isCalled, "Configure was NOT called: " + GetType().Name);
    
    protected override void OnDestroy()
    {
        if (s_instance == this)
        {
            base.OnDestroy();
        }
    }
    
    protected override void Configure(IContainerBuilder builder) => _isCalled = true;
}
```

#### ReloadTestLifetimeScope.cs
a LifetimeScope with a singleton LifetimeScope as Parent
```c#
using UnityEngine.Assertions;
using VContainer;
using VContainer.Unity;

public sealed class ReloadTestLifetimeScope : LifetimeScope
{
    bool _isCalled;
    
    void Start() => Assert.IsTrue(_isCalled, "Configure was NOT called: " + GetType().Name);
    
    protected override void Configure(IContainerBuilder builder) => _isCalled = true;

    void Reset() => parentReference = ParentReference.Create<DontDestroyOnLoadLifetimeScope>();
}
```

#### ReloadScene.cs
Scene reloading.
```c#
using System.Threading.Tasks;
using UnityEngine;
using UnityEngine.SceneManagement;

public sealed class ReloadScene : MonoBehaviour
{
    async void Start()
    {
        try
        {
            await Task.Delay(1000, cancellationToken:destroyCancellationToken);
            SceneManager.LoadScene(SceneManager.GetActiveScene().name);
        }
        catch
        {
            // ignore
        }
    }
}
```

## Problem solved

Fixed so that if multiple LifetimeScope of the same class exist, the LifetimeScope with DontDestroyOnLoad is returned. The reason is that there are no other situations where multiple LifetimeScope exist. Also, if there are no more than one, the first one in the array is returned. Internally, this is exactly the same code as the previous code.

#### Current

https://github.com/hadashiA/VContainer/blob/583d0211d2ae0a70b689d6fb08b506e79ea8ad70/VContainer/Assets/VContainer/Runtime/Unity/LifetimeScope.cs#L118-L125

#### After

https://github.com/hadashiA/VContainer/blob/0119b2da80e724d4149507166f6d27426b0ed48a/VContainer/Assets/VContainer/Runtime/Unity/LifetimeScope.cs#L118-L137

## About performance

As explained, performance is the same as before when there is no more than one. The internal implementation of `FindAnyObjectByType` and `FindObjectOfType` used is as follows.

```c#
public static Object FindAnyObjectByType(System.Type type)
{
  Object[] objectsByType = Object.FindObjectsByType(type, FindObjectsInactive.Exclude, FindObjectsSortMode.None);
  return objectsByType.Length != 0 ? objectsByType[0] : (Object) null;
}


[TypeInferenceRule(TypeInferenceRules.TypeReferencedByFirstArgument)]
public static Object FindObjectOfType(System.Type type)
{
  Object[] objectsOfType = Object.FindObjectsOfType(type, false);
  return objectsOfType.Length != 0 ? objectsOfType[0] : (Object) null;
}
```

## FindObjectsOfType handling

In my testing, `FindObjectOfType` was always stored in the array in the order it was created, as opposed to `FindAnyObjectByType`, but since there seems to be no guarantee of order, I made the same modification to give priority to DontDestroyOnLoad The same modification has been made to prioritize DontDestroyOnLoad.