### PR TITLE
Fix an issue with Start being called multiple times with exception

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/Unity/ContainerBuilderUnityExtensions.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/ContainerBuilderUnityExtensions.cs
@@ -14,6 +14,9 @@ namespace VContainer.Unity
         {
             if (containerBuilder.Exists(typeof(EntryPointDispatcher), false)) return;
             containerBuilder.Register<EntryPointDispatcher>(Lifetime.Scoped);
+
+            containerBuilder.RegisterEntryPointExceptionHandler(UnityEngine.Debug.LogException);
+
             containerBuilder.RegisterBuildCallback(container =>
             {
                 container.Resolve<EntryPointDispatcher>().Dispatch();
@@ -120,7 +123,7 @@ namespace VContainer.Unity
             this IContainerBuilder builder,
             Action<Exception> exceptionHandler)
         {
-            builder.RegisterInstance(new EntryPointExceptionHandler(exceptionHandler));
+            builder.Register(c => new EntryPointExceptionHandler(exceptionHandler), Lifetime.Scoped);
         }
 
         public static RegistrationBuilder RegisterComponent<TInterface>(
@@ -197,7 +200,7 @@ namespace VContainer.Unity
         {
             return builder.RegisterComponentInNewPrefab(typeof(T), prefab, lifetime);
         }
-        
+
         public static ComponentRegistrationBuilder RegisterComponentInNewPrefab<T>(
             this IContainerBuilder builder,
             Func<IObjectResolver, T> prefab,
@@ -206,7 +209,7 @@ namespace VContainer.Unity
         {
             return builder.Register(new ComponentRegistrationBuilder(prefab, typeof(T), lifetime));
         }
-        
+
         public static ComponentRegistrationBuilder RegisterComponentInNewPrefab<TInterface, TImplement>(
             this IContainerBuilder builder,
             Func<IObjectResolver, TImplement> prefab,
@@ -300,7 +303,7 @@ namespace VContainer.Unity
             Type refType = typeof(UnmanagedSystemReference<>);
             Type target = refType.MakeGenericType(typeof(T));
             var reference = (UnmanagedSystemReference)Activator.CreateInstance(target, system, world);
-            
+
             return builder.RegisterComponent(reference)
                 .As(target);
         }

--- a/VContainer/Assets/VContainer/Runtime/Unity/EntryPointDispatcher.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/EntryPointDispatcher.cs
@@ -22,7 +22,7 @@ namespace VContainer.Unity
         {
             PlayerLoopHelper.EnsureInitialized();
 
-            EntryPointExceptionHandler exceptionHandler = container.ResolveOrDefault<EntryPointExceptionHandler>();
+            var exceptionHandler = container.ResolveOrDefault<EntryPointExceptionHandler>();
 
             var initializables = container.Resolve<ContainerLocal<IReadOnlyList<IInitializable>>>().Value;
             for (var i = 0; i < initializables.Count; i++)

--- a/VContainer/UserSettings/Layouts/default-2021.dwlt
+++ b/VContainer/UserSettings/Layouts/default-2021.dwlt
@@ -48,7 +48,7 @@ MonoBehaviour:
   m_MinSize: {x: 300, y: 200}
   m_MaxSize: {x: 24288, y: 16192}
   vertical: 0
-  controlID: 83
+  controlID: 84
 --- !u!114 &3
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -223,7 +223,7 @@ MonoBehaviour:
   m_MinSize: {x: 200, y: 200}
   m_MaxSize: {x: 16192, y: 16192}
   vertical: 1
-  controlID: 84
+  controlID: 63
 --- !u!114 &10
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -248,7 +248,7 @@ MonoBehaviour:
   m_MinSize: {x: 200, y: 100}
   m_MaxSize: {x: 16192, y: 8096}
   vertical: 0
-  controlID: 85
+  controlID: 64
 --- !u!114 &11
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -333,7 +333,7 @@ MonoBehaviour:
     scrollPos: {x: 0, y: 0}
     m_SelectedIDs: 84440000
     m_LastClickedID: 17540
-    m_ExpandedIDs: 0000000086440000
+    m_ExpandedIDs: 000000006e440000
     m_RenameOverlay:
       m_UserAcceptedRename: 0
       m_Name: 
@@ -361,7 +361,7 @@ MonoBehaviour:
     scrollPos: {x: 0, y: 0}
     m_SelectedIDs: 
     m_LastClickedID: 0
-    m_ExpandedIDs: 0000000086440000
+    m_ExpandedIDs: 000000006e440000
     m_RenameOverlay:
       m_UserAcceptedRename: 0
       m_Name: 
@@ -495,7 +495,7 @@ MonoBehaviour:
       scrollPos: {x: 0, y: 0}
       m_SelectedIDs: 
       m_LastClickedID: 0
-      m_ExpandedIDs: 1efbffff
+      m_ExpandedIDs: 30fbffff
       m_RenameOverlay:
         m_UserAcceptedRename: 0
         m_Name: 


### PR DESCRIPTION
#729 

It used to throw an exception in `Start`, but this is uncatchable anyway, so I changed the default behavior to `UnityEngine.Debug.LogException` instead of throw.
