### PR TITLE
Add InjectAttribute to BuilderCallbackDisposable constructor

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/Internal/BuilderCallbackDisposable.cs
+++ b/VContainer/Assets/VContainer/Runtime/Internal/BuilderCallbackDisposable.cs
@@ -7,6 +7,7 @@ namespace VContainer.Internal
         public event Action<IObjectResolver> Disposing;
         readonly IObjectResolver container;
 
+        [Inject]
         public BuilderCallbackDisposable(IObjectResolver container)
         {
             this.container = container;


### PR DESCRIPTION
Although BuilderCallbackDisposable was registered with Register, there was no constructor call and no InjectAttribute was attached, so I added an InjectAttribute. 