### PR TITLE
Issue#739 Always parents created child lifetime scope game object

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/Unity/LifetimeScope.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/LifetimeScope.cs
@@ -230,14 +230,8 @@ namespace VContainer.Unity
         {
             var childGameObject = new GameObject(childScopeName ?? "LifetimeScope (Child)");
             childGameObject.SetActive(false);
-            if (IsRoot)
-            {
-                DontDestroyOnLoad(childGameObject);
-            }
-            else
-            {
-                childGameObject.transform.SetParent(transform, false);
-            }
+            childGameObject.transform.SetParent(transform, false);
+
             var child = childGameObject.AddComponent<TScope>();
             if (installer != null)
             {


### PR DESCRIPTION
PR to addres this issue: https://github.com/hadashiA/VContainer/issues/739

If the parent lifetime scope is the root, parenting the child lifetime scope game object to it would automatically make it "not be destroyed on load" (DontDestroyOnLoad).

This change results in all `CreateChild` api behave the same with regards to their game object parent/child relationship (previous discrepancy was outlined in the issue linked above).