### PR TITLE
Added TryAs in RegistrationBuilder - a version of As that doesn't throw

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/Internal/OpenGenericRegistrationBuilder.cs
+++ b/VContainer/Assets/VContainer/Runtime/Internal/OpenGenericRegistrationBuilder.cs
@@ -31,7 +31,7 @@ namespace VContainer.Internal
             return this;
         }
 
-        protected override void AddInterfaceType(Type interfaceType)
+        protected override void AddInterfaceType(Type interfaceType, bool throwException = true)
         {
             if (interfaceType.IsConstructedGenericType)
                 throw new VContainerException(interfaceType, "Type is not open generic type.");
@@ -52,7 +52,7 @@ namespace VContainer.Internal
                 return;
             }
 
-            base.AddInterfaceType(interfaceType);
+            base.AddInterfaceType(interfaceType, throwException);
         }
     }
 }

--- a/VContainer/Assets/VContainer/Runtime/RegistrationBuilder.cs
+++ b/VContainer/Assets/VContainer/Runtime/RegistrationBuilder.cs
@@ -41,6 +41,18 @@ namespace VContainer
         public RegistrationBuilder As<TInterface1, TInterface2, TInterface3, TInterface4>()
             => As(typeof(TInterface1), typeof(TInterface2), typeof(TInterface3), typeof(TInterface4));
 
+        public RegistrationBuilder TryAs<TInterface>()
+            => TryAs(typeof(TInterface));
+
+        public RegistrationBuilder TryAs<TInterface1, TInterface2>()
+            => TryAs(typeof(TInterface1), typeof(TInterface2));
+
+        public RegistrationBuilder TryAs<TInterface1, TInterface2, TInterface3>()
+            => TryAs(typeof(TInterface1), typeof(TInterface2), typeof(TInterface3));
+
+        public RegistrationBuilder TryAs<TInterface1, TInterface2, TInterface3, TInterface4>()
+            => TryAs(typeof(TInterface1), typeof(TInterface2), typeof(TInterface3), typeof(TInterface4));
+
         public RegistrationBuilder AsSelf()
         {
             AddInterfaceType(ImplementationType);
@@ -80,6 +92,36 @@ namespace VContainer
             foreach (var interfaceType in interfaceTypes)
             {
                 AddInterfaceType(interfaceType);
+            }
+            return this;
+        }
+
+        public RegistrationBuilder TryAs(Type interfaceType)
+        {
+            AddInterfaceType(interfaceType, false);
+            return this;
+        }
+
+        public RegistrationBuilder TryAs(Type interfaceType1, Type interfaceType2)
+        {
+            AddInterfaceType(interfaceType1, false);
+            AddInterfaceType(interfaceType2, false);
+            return this;
+        }
+
+        public RegistrationBuilder TryAs(Type interfaceType1, Type interfaceType2, Type interfaceType3)
+        {
+            AddInterfaceType(interfaceType1, false);
+            AddInterfaceType(interfaceType2, false);
+            AddInterfaceType(interfaceType3, false);
+            return this;
+        }
+        
+        public RegistrationBuilder TryAs(params Type[] interfaceTypes)
+        {
+            foreach (var interfaceType in interfaceTypes)
+            {
+                AddInterfaceType(interfaceType, false);
             }
             return this;
         }
@@ -127,11 +169,16 @@ namespace VContainer
             return WithParameter(typeof(TParam), _ => value());
         }
 
-        protected virtual void AddInterfaceType(Type interfaceType)
+        protected virtual void AddInterfaceType(Type interfaceType, bool throwException = true)
         {
             if (!interfaceType.IsAssignableFrom(ImplementationType))
             {
-                throw new VContainerException(interfaceType, $"{ImplementationType} is not assignable from {interfaceType}");
+                if (throwException)
+                {
+                    throw new VContainerException(interfaceType, $"{ImplementationType} is not assignable from {interfaceType}");
+                }
+
+                return;
             }
             InterfaceTypes = InterfaceTypes ?? new List<Type>();
             if (!InterfaceTypes.Contains(interfaceType))


### PR DESCRIPTION
Sometimes a concrete type could implement multiple interfaces and the instance of the concrete type needs to be registered against those interface. 

Currently, we have the options below:

1. `AsImplementedInterfaces()`

```csharp
builder.RegisterInstance(instance).AsImplementedInterfaces();
```
Straightforward and neat! However, I try to avoid using this as it hides away registrations of types. My IDE can't help me find where a certain type is registered.

2. Explicitly registering against the interfaces
```csharp
builder.RegisterInstance<IInterfaceA, IInterfaceB, IInterfaceC>(instance);
// or
builder.RegisterInstance(instance)
    .As<IInterfaceA>()
    .As<IInterfaceB>()
    .As<IInterfaceC>();
```
Still relatively straightforward and neat! In addition, I can now easily see what the instance is registered against. My IDE can easily find these registrations.

---
Now, there are cases where it is not guaranteed that an instance implements a certain interface, but still needed to be registered if it is. Option 1 can handle this easily as it will only register against implemented interfaces. However, option 2 will fail and rightly throw an exception.

A way around this is to manually check the instance against the interfaces:
```csharp
var registrationBuilder = builder.RegisterInstance(instance);

if (instance is IInterfaceA)
{
    registrationBuilder = registrationBuilder.As<IInterfaceA>();
}
if (instance is IInterfaceB)
{
    registrationBuilder = registrationBuilder.As<IInterfaceB>();
}
if (instance is IInterfaceC)
{
    registrationBuilder.As<IInterfaceC>();
}
```
This is cumbersome the more interfaces you need to check against.

---
This PR adds a new version of `As` that doesn't throw an exception if the instance does not implement the interface it's being registered against: `TryAs`

With this, we can write above similar to option 2:
```csharp
builder.RegisterInstance(instance)
   .TryAs<IInterfaceA>()
   .TryAs<IInterfaceB>()
   .TryAs<IInterfaceC>();
```
Back to straightforward and neat!

_Note: I went for a very simple implementation and just added a boolean flag to the `AddInterfaceType` method. Feel free to come up with a better implementation._
