### PR TITLE
Fixed compilation error on older unity versions

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/Internal/FixedTypeObjectKeyHashtable.cs
+++ b/VContainer/Assets/VContainer/Runtime/Internal/FixedTypeObjectKeyHashtable.cs
@@ -51,7 +51,7 @@ namespace VContainer.Internal
                     var newArray = new HashEntry[array.Length + 1];
                     Array.Copy(array, newArray, array.Length);
                     array = newArray;
-                    array[^1] = new HashEntry(item.Key.Item1, item.Key.Item2, item.Value);
+                    array[array.Length - 1] = new HashEntry(item.Key.Item1, item.Key.Item2, item.Value);
                 }
 
                 table[hash & indexFor] = array;


### PR DESCRIPTION
After the merge of Keyed registrations PR, I noticed that some checks haven't passed. 
Looked into it and it's due to older C# version in earlier Unity versions. 
This minor fix should do it.