### PR TITLE
BugFix: Was able to create a component with `new` keyword

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/Internal/ReflectionInjector.cs
+++ b/VContainer/Assets/VContainer/Runtime/Internal/ReflectionInjector.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using System.Reflection;
 
 namespace VContainer.Internal
 {

--- a/VContainer/Assets/VContainer/Runtime/Internal/ReflectionInjector.cs
+++ b/VContainer/Assets/VContainer/Runtime/Internal/ReflectionInjector.cs
@@ -31,6 +31,11 @@ namespace VContainer.Internal
 
         public object CreateInstance(IObjectResolver resolver, IReadOnlyList<IInjectParameter> parameters)
         {
+            if (typeof(UnityEngine.Component).IsAssignableFrom(injectTypeInfo.Type))
+            {
+                throw new NotSupportedException($"UnityEngine.Component:{injectTypeInfo.Type.Name} cannot be `new`");
+            }
+
             var parameterInfos = injectTypeInfo.InjectConstructor.ParameterInfos;
             var parameterKeys = injectTypeInfo.InjectConstructor.ParameterKeys;
             var parameterValues = CappedArrayPool<object>.Shared8Limit.Rent(parameterInfos.Length);


### PR DESCRIPTION
When working with source generators, if you try to do something like this on a class that inherits from `Component`, you will receive a `NotSupportedException` when trying to inject it.

```csharp
builder.Register<SomeMonoBehaviour>(Lifetime.Singleton);
```

When working with reflection injection, the creation of a component that way is allowed.

This PR aims to align the implementations and to prevent a reflection created instances of Components.

⚠️ This might be a "breaking change" for some who used this approach in their project intentionally or not (in our case it was unintentional and it was causing havoc).