### PR TITLE
[Website/Docs] Added Support for Diff Syntax Highlight

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -93,7 +93,7 @@ const config: Config = {
       // },
     },
     prism: {
-      additionalLanguages: ['csharp'],
+      additionalLanguages: ['csharp', 'diff'],
       theme: prismThemes.vsDark,
       darkTheme: prismThemes.vsDark,
     },


### PR DESCRIPTION
Before:

<img width="1382" height="527" alt="image" src="https://github.com/user-attachments/assets/e2cf57ea-ce47-4116-a606-a31fe6822f33" />

After

<img width="1265" height="491" alt="image" src="https://github.com/user-attachments/assets/7ece6a4d-284c-4464-b90e-538a5e78d4e7" />
