### PR TITLE
Fix: Unity RegisterComponent with Keyed Throws Exception

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/Unity/ContainerBuilderUnityExtensions.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/ContainerBuilderUnityExtensions.cs
@@ -132,7 +132,7 @@ namespace VContainer.Unity
         {
             var registrationBuilder = new ComponentRegistrationBuilder(component).As(typeof(TInterface));
             // Force inject execution
-            builder.RegisterBuildCallback(container => container.Resolve<TInterface>());
+            builder.RegisterBuildCallback(container => container.Resolve<TInterface>(registrationBuilder.Key));
             return builder.Register(registrationBuilder);
         }
 
@@ -151,7 +151,8 @@ namespace VContainer.Unity
                     container.Resolve(
                         registrationBuilder.InterfaceTypes != null
                             ? registrationBuilder.InterfaceTypes[0]
-                            : registrationBuilder.ImplementationType
+                            : registrationBuilder.ImplementationType,
+                        registrationBuilder.Key
                     );
                 }
             );


### PR DESCRIPTION
This pull request is related to issue #794. 

**The Problem:**
In the current implementation of `RegisterComponent` and `RegisterComponentInHierarchy`, a build callback is registered to force injection by calling `container.Resolve()`. However, it ignores the key that might be subsequently configured via `.Keyed(key)`. This leads to a `VContainerException` during the build phase because the container tries to resolve a default (unkeyed) registration that doesn't exist. Also, the keyed registration will not be force injected.

Though the main purpose of `RegisterComponent` is to trigger auto-injection, since it returns a `RegistrationBuilder`, I believe ensuring it respects the key parameter is important for internal state consistency.

**The Solution:**
Passed `registrationBuilder.Key` into the `Resolve` method within the build callback. Since the default value of the `key` parameter in `Resolve` is null, I think this change is backward compatible and correctly handles both keyed and non-keyed registrations.