### PR TITLE
fix: resolve GetInstanceID deprecation in Unity 6.4+

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/Unity/LifetimeScope.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/LifetimeScope.cs
@@ -136,7 +136,11 @@ namespace VContainer.Unity
         {
             if (VContainerSettings.DiagnosticsEnabled && string.IsNullOrEmpty(scopeName))
             {
+#if UNITY_6000_4_OR_NEWER
+                scopeName = $"{name} ({gameObject.GetEntityId()})";
+#else
                 scopeName = $"{name} ({gameObject.GetInstanceID()})";
+#endif
             }
             try
             {


### PR DESCRIPTION
## Description

Unity 6.4 has deprecated `Object.GetInstanceID()` (warning), and it will be treated as a compilation error (CS0619) from Unity 6.5 onwards.

This PR addresses the issue by:
- Using `GetEntityId()` for Unity 6.4 and newer versions.
- Maintaining backward compatibility for older Unity versions using conditional compilation (`#if UNITY_6000_4_OR_NEWER`).

**Changes:**

- Modified `LifetimeScope.cs` to use the appropriate unique identifier API based on the Unity version.
