### PR TITLE
Add `INonLazy` interface for immediate instantiation via `RegisterEntryPoint`

### DIFF
--- a/VContainer/Assets/Tests/Unity/Fixtures/SampleEntryPoint.cs
+++ b/VContainer/Assets/Tests/Unity/Fixtures/SampleEntryPoint.cs
@@ -165,4 +165,14 @@ namespace VContainer.Tests.Unity
             => throw new System.NotImplementedException();
     }
 #endif
+
+    public class SampleNonLazyEntryPoint : INonLazy
+    {
+        public static int InstanceCount;
+
+        public SampleNonLazyEntryPoint()
+        {
+            InstanceCount++;
+        }
+    }
 }

--- a/VContainer/Assets/Tests/Unity/UnityContainerBuilderTest.cs
+++ b/VContainer/Assets/Tests/Unity/UnityContainerBuilderTest.cs
@@ -461,6 +461,22 @@ namespace VContainer.Tests.Unity
             Assert.That(created.transform.parent, Is.EqualTo(go3.transform));
         }
 
+        [Test]
+        public void RegisterNonLazyEntryPoint()
+        {
+            SampleNonLazyEntryPoint.InstanceCount = 0;
+
+            var builder = new ContainerBuilder();
+            builder.RegisterEntryPoint<SampleNonLazyEntryPoint>();
+
+            var container = builder.Build();
+            Assert.That(SampleNonLazyEntryPoint.InstanceCount, Is.EqualTo(1));
+
+            var resolved = container.Resolve<INonLazy>();
+            Assert.That(resolved, Is.InstanceOf<SampleNonLazyEntryPoint>());
+            Assert.That(SampleNonLazyEntryPoint.InstanceCount, Is.EqualTo(1));
+        }
+
         [UnityTest]
         public IEnumerator DispatchMonoBehaviour()
         {

--- a/VContainer/Assets/VContainer/Runtime/Annotations/INonLazy.cs
+++ b/VContainer/Assets/VContainer/Runtime/Annotations/INonLazy.cs
@@ -1,0 +1,4 @@
+﻿namespace VContainer.Unity
+{
+    public interface INonLazy { }
+}

--- a/VContainer/Assets/VContainer/Runtime/Annotations/INonLazy.cs.meta
+++ b/VContainer/Assets/VContainer/Runtime/Annotations/INonLazy.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 1b22fa34907a459799a1d64fa76a0a72
+timeCreated: 1775234550

--- a/VContainer/Assets/VContainer/Runtime/Unity/EntryPointDispatcher.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/EntryPointDispatcher.cs
@@ -24,6 +24,8 @@ namespace VContainer.Unity
 
             var exceptionHandler = container.ResolveOrDefault<EntryPointExceptionHandler>();
 
+            container.Resolve<ContainerLocal<IReadOnlyList<INonLazy>>>();
+
             var initializables = container.Resolve<ContainerLocal<IReadOnlyList<IInitializable>>>().Value;
             for (var i = 0; i < initializables.Count; i++)
             {


### PR DESCRIPTION
This PR introduces a new approach to support non-lazy initialization, inspired by previous discussions around the `NonLazy()` method. Instead of using a separate `NonLazy()` API, I provide an `INonLazy` marker interface.  

Perhaps this approach will be more aligned with the repository owner's preferences. For reference, see the previous discussion: [PR #574](https://github.com/hadashiA/VContainer/pull/574).

## Key Points
- Types implementing `INonLazy` will be automatically instantiated when registered via `RegisterEntryPoint`, ensuring immediate construction.
- This avoids the need for empty `Initialize()` implementations solely to trigger early instantiation.
- Follows the existing pattern of `RegisterEntryPoint()`, maintaining API consistency and clarity.
- Includes unit tests demonstrating proper instantiation order and behavior.

## Example Usage

```csharp
public class MyListener : INonLazy
{
    public MyListener()
    {
        EventBus.Subscribe<MyEvent>(OnEvent);
    }

    private void OnEvent(MyEvent e)
    {
        // handle event
    }
}

// Registration
container.RegisterEntryPoint<MyListener>();
// MyListener is created immediately after container build