### PR TITLE
Fix duplicate types in `VContainerSourceGenerator`

### DIFF
--- a/VContainer.SourceGenerator.Roslyn3/VContainerSourceGenerator.cs
+++ b/VContainer.SourceGenerator.Roslyn3/VContainerSourceGenerator.cs
@@ -23,6 +23,7 @@ public class VContainerSourceGenerator : ISourceGenerator
 
         var codeWriter = new CodeWriter();
         var syntaxCollector = (SyntaxCollector)context.SyntaxReceiver!;
+        var generatedTypes = new System.Collections.Generic.HashSet<ISymbol>(SymbolEqualityComparer.Default);
         foreach (var workItem in syntaxCollector.WorkItems)
         {
             if (workItem.TypeDeclarationSyntax is { } typeDeclarationSyntax)
@@ -31,6 +32,8 @@ public class VContainerSourceGenerator : ISourceGenerator
                 var typeDeclarationCandidate = new TypeDeclarationCandidate(typeDeclarationSyntax, semanticModel);
                 if (typeDeclarationCandidate.Analyze(references) is { } typeMeta)
                 {
+                    if (!generatedTypes.Add(typeMeta.Symbol)) continue;
+
                     Execute(typeMeta, codeWriter, references, in context);
                     codeWriter.Clear();
                 }
@@ -42,6 +45,8 @@ public class VContainerSourceGenerator : ISourceGenerator
                 var typeMetas = registerInvocationCandidate.Analyze(references);
                 foreach (var typeMeta in typeMetas)
                 {
+                    if (!generatedTypes.Add(typeMeta.Symbol)) continue;
+
                     Execute(typeMeta, codeWriter, references, in context);
                     codeWriter.Clear();
                 }


### PR DESCRIPTION
**Preconditions**
Have multiple assembly defenitions
- `AssemblyA` - no references
- `AssemblyB` - references `AssemblyA`; `LifetimeScope` references `AssemblyA`


**Problem**
This setup causes generator to emit the same generated injector multiple times.


**Result**
Silent throw during build:
`CSC: Warning CS8785 : Generator 'VContainerSourceGenerator' failed to generate source. It will not contribute to the output and compilation errors may occur as a result. Exception was of type 'ArgumentException' with message 'The hintName 'XGeneratedInjector.g.cs' of the added source file must be unique within a generator.`
This causes no generated types, except for `AssemblyA`.


**Cause**
The generator uses `FullTypeName` as the `hintName` for `AddSource`, but does not guarantee uniqueness across all collected `TypeMeta` results.


**Solution**
A `HashSet` is used to track generated types and prevent duplicate `AddSource` calls.


**Testing**
Verified locally in a Unity project that has this issue.
After applying the fix, all injectors are generated successfully without warnings or exceptions.


**Notes**
I touched `VContainer.SourceGenerator.Roslyn3.Execute(GeneratorExecutionContext context)` method only, because I use Roslyn one, while there might be similar issue in `VContainer.SourceGenerator`.