### PR TITLE
Refactor: Separate AutoInject from SetContainer build callback

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/Unity/LifetimeScope.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/LifetimeScope.cs
@@ -202,7 +202,6 @@ namespace VContainer.Unity
                 // ReSharper disable once PossibleNullReferenceException
                 Parent.Container.CreateScope(builder =>
                 {
-                    builder.RegisterBuildCallback(SetContainer);
                     builder.ApplicationOrigin = this;
                     builder.Diagnostics = VContainerSettings.DiagnosticsEnabled ? DiagnositcsContext.GetCollector(scopeName) : null;
                     InstallTo(builder);
@@ -215,7 +214,6 @@ namespace VContainer.Unity
                     ApplicationOrigin = this,
                     Diagnostics = VContainerSettings.DiagnosticsEnabled ? DiagnositcsContext.GetCollector(scopeName) : null,
                 };
-                builder.RegisterBuildCallback(SetContainer);
                 InstallTo(builder);
                 builder.Build();
             }
@@ -226,7 +224,6 @@ namespace VContainer.Unity
         void SetContainer(IObjectResolver container)
         {
             Container = container;
-            AutoInjectAll();
         }
 
         public TScope CreateChild<TScope>(IInstaller installer = null, string childScopeName = null)
@@ -287,8 +284,8 @@ namespace VContainer.Unity
 
         void InstallTo(IContainerBuilder builder)
         {
+            builder.RegisterBuildCallback(SetContainer);
             Configure(builder);
-
             foreach (var installer in localExtraInstallers)
             {
                 installer.Install(builder);
@@ -304,6 +301,7 @@ namespace VContainer.Unity
             }
 
             builder.RegisterInstance<LifetimeScope>(this).AsSelf();
+            builder.RegisterBuildCallback(AutoInjectAll);
             EntryPointsBuilder.EnsureDispatcherRegistered(builder);
         }
 
@@ -356,7 +354,7 @@ namespace VContainer.Unity
             return null;
         }
 
-        void AutoInjectAll()
+        void AutoInjectAll(IObjectResolver container)
         {
             if (autoInjectGameObjects == null)
                 return;


### PR DESCRIPTION
- Move `RegisterBuildCallback(SetContainer)` to start of `InstallTo`.
- Separate `AutoInjectAll` from `SetContainer` and add to container build callback at the end of `InstallTo`

Currently, `SetContainer` is registered as a build callback before `InstallTo` is called and `AutoInjectAll` is call inside `SetContainer`, meaning user-defined container build callbacks will be called after MonoBehaviours are auto-injected via LifetimeScope.

This change separate `AutoInjectAll` from `SetContainer` and add `builder.RegisterBuildCallback(AutoInjectAll)` to the end of `InstallTo`, ensuring it is always the last registered build callback. As a result, when MonoBehaviours are auto-injected via LifetimeScope, all container build callbacks (including any registered by user installers) are guaranteed to have completed first.

**Before:** `SetContainer` (with `AutoInjectAll`) callback was registered before InstallTo, so it could be invoked before user-defined callbacks.
**After:**  `AutoInjectAll` is separated from `SetContainer`, add `AutoInjectAll` as last container build callback so it runs after all other build callbacks have finished.