### PR TITLE
Optimizing the circular dependency detection

### DIFF
--- a/VContainer/Assets/Tests/ContainerTest.cs
+++ b/VContainer/Assets/Tests/ContainerTest.cs
@@ -571,6 +571,55 @@ namespace VContainer.Tests
         }
 
         [Test]
+        public void SelfCircularDependency()
+        {
+            var builder = new ContainerBuilder();
+            builder.Register<HasSelfCircularDependency>(Lifetime.Transient);
+
+            var injector = InjectorCache.GetOrBuild(typeof(HasSelfCircularDependency));
+
+            if (injector is ReflectionInjector)
+            {
+                Assert.Throws<VContainerException>(() => builder.Build());
+            }
+        }
+
+        [Test]
+        public void DiamondDependencyIsNotCircular()
+        {
+            var builder = new ContainerBuilder();
+            builder.Register<DiamondRoot>(Lifetime.Transient);
+            builder.Register<DiamondLeft>(Lifetime.Transient);
+            builder.Register<DiamondRight>(Lifetime.Transient);
+            builder.Register<DiamondLeaf>(Lifetime.Transient);
+
+            Assert.DoesNotThrow(() => builder.Build());
+        }
+
+        [Test]
+        public void DeepAcyclicChainIsNotCircular()
+        {
+            var builder = new ContainerBuilder();
+            builder.Register<AcyclicChainA>(Lifetime.Transient);
+            builder.Register<AcyclicChainB>(Lifetime.Transient);
+            builder.Register<AcyclicChainC>(Lifetime.Transient);
+            builder.Register<AcyclicChainD>(Lifetime.Transient);
+
+            Assert.DoesNotThrow(() => builder.Build());
+        }
+
+        [Test]
+        public void SharedDependencyAcrossRootsIsNotCircular()
+        {
+            var builder = new ContainerBuilder();
+            builder.Register<DiamondLeft>(Lifetime.Transient);
+            builder.Register<DiamondRight>(Lifetime.Transient);
+            builder.Register<DiamondLeaf>(Lifetime.Transient);
+
+            Assert.DoesNotThrow(() => builder.Build());
+        }
+
+        [Test]
         public void Inject()
         {
             var builder = new ContainerBuilder();

--- a/VContainer/Assets/Tests/Fixtures.cs
+++ b/VContainer/Assets/Tests/Fixtures.cs
@@ -294,6 +294,91 @@ namespace VContainer.Tests
         [Inject] public HasCircularDependencyMsg1 Prop { get; set; }
     }
 
+    class HasSelfCircularDependency
+    {
+        public HasSelfCircularDependency(HasSelfCircularDependency self)
+        {
+            if (self == null)
+            {
+                throw new ArgumentException();
+            }
+        }
+    }
+
+    class DiamondLeaf
+    {
+    }
+
+    class DiamondLeft
+    {
+        public DiamondLeft(DiamondLeaf leaf)
+        {
+            if (leaf == null)
+            {
+                throw new ArgumentException();
+            }
+        }
+    }
+
+    class DiamondRight
+    {
+        public DiamondRight(DiamondLeaf leaf)
+        {
+            if (leaf == null)
+            {
+                throw new ArgumentException();
+            }
+        }
+    }
+
+    class DiamondRoot
+    {
+        public DiamondRoot(DiamondLeft left, DiamondRight right)
+        {
+            if (left == null || right == null)
+            {
+                throw new ArgumentException();
+            }
+        }
+    }
+
+    class AcyclicChainA
+    {
+        public AcyclicChainA(AcyclicChainB b)
+        {
+            if (b == null)
+            {
+                throw new ArgumentException();
+            }
+        }
+    }
+
+    class AcyclicChainB
+    {
+        public AcyclicChainB(AcyclicChainC c)
+        {
+            if (c == null)
+            {
+                throw new ArgumentException();
+            }
+        }
+    }
+
+    class AcyclicChainC
+    {
+        public AcyclicChainC(AcyclicChainD d)
+        {
+            if (d == null)
+            {
+                throw new ArgumentException();
+            }
+        }
+    }
+
+    class AcyclicChainD
+    {
+    }
+
     class HasMethodInjection : I1
     {
         public I2 Service2;

--- a/VContainer/Assets/VContainer/Runtime/Internal/TypeAnalyzer.cs
+++ b/VContainer/Assets/VContainer/Runtime/Internal/TypeAnalyzer.cs
@@ -213,6 +213,12 @@ namespace VContainer.Internal
         [ThreadStatic]
         static Stack<DependencyInfo> circularDependencyChecker;
 
+        [ThreadStatic]
+        static HashSet<Type> visitingTypes;
+
+        [ThreadStatic]
+        static HashSet<Type> verifiedTypes;
+
         static readonly Func<Type, InjectTypeInfo> AnalyzeFunc = Analyze;
 
         public static InjectTypeInfo Analyze(Type type)
@@ -368,8 +374,12 @@ namespace VContainer.Internal
         public static void CheckCircularDependency(IReadOnlyList<Registration> registrations, Registry registry)
         {
             // ThreadStatic
-            if (circularDependencyChecker == null)
-                circularDependencyChecker = new Stack<DependencyInfo>();
+            circularDependencyChecker ??= new Stack<DependencyInfo>();
+            visitingTypes ??= new HashSet<Type>();
+            verifiedTypes ??= new HashSet<Type>();
+
+            visitingTypes.Clear();
+            verifiedTypes.Clear();
 
             for (var i = 0; i < registrations.Count; i++)
             {
@@ -380,27 +390,33 @@ namespace VContainer.Internal
 
         static void CheckCircularDependencyRecursive(DependencyInfo current, Registry registry, Stack<DependencyInfo> stack)
         {
-            var i = 0;
-            foreach (var dependency in stack)
+            var currentType = current.ImplementationType;
+
+            if (verifiedTypes.Contains(currentType))
+                return;
+
+            if (!visitingTypes.Add(currentType))
             {
-                if (current.ImplementationType == dependency.ImplementationType)
+                // When instantiated by Func, the abstract type cycle is user-avoidable.
+                if (current.Dependency.Provider is FuncInstanceProvider)
+                    return;
+
+                stack.Push(current);
+
+                var i = 0;
+                foreach (var dependency in stack)
                 {
-                    // When instantiated by Func, the abstract type cycle is user-avoidable.
-                    if (current.Dependency.Provider is FuncInstanceProvider)
-                    {
-                        return;
-                    }
-
-                    stack.Push(current);
-
-                    var path = string.Join("\n",
-                        stack.Take(i + 1)
-                            .Reverse()
-                            .Select((item, itemIndex) => $"    [{itemIndex + 1}] {item} --> {item.ImplementationType.FullName}"));
-                    throw new VContainerException(current.Dependency.ImplementationType,
-                        $"Circular dependency detected!\n{path}");
+                    if (i > 0 && current.ImplementationType == dependency.ImplementationType)
+                        break;
+                    i++;
                 }
-                i++;
+
+                var path = string.Join("\n",
+                    stack.Take(i)
+                        .Reverse()
+                        .Select((item, itemIndex) => $"    [{itemIndex + 1}] {item} --> {item.ImplementationType.FullName}"));
+                throw new VContainerException(current.Dependency.ImplementationType,
+                    $"Circular dependency detected!\n{path}");
             }
 
             stack.Push(current);
@@ -464,6 +480,8 @@ namespace VContainer.Internal
             }
 
             stack.Pop();
+            visitingTypes.Remove(currentType);
+            verifiedTypes.Add(currentType);
         }
     }
 }


### PR DESCRIPTION
Problem: The circular dependency checker was running in exponential time, checking every single type on every method call.

Changes:
* Memoizing the result for correct types so we don't recalculate them every time. 
* Store the visiting types in a set so we don't have to iterate the entire stack every time.
* Added tests