### PR TITLE
Fix: use DestroyImmediate when disposing LifetimeScope outside Play Mode

### DIFF
--- a/VContainer/Assets/VContainer/Runtime/Unity/LifetimeScope.cs
+++ b/VContainer/Assets/VContainer/Runtime/Unity/LifetimeScope.cs
@@ -171,7 +171,14 @@ namespace VContainer.Unity
             DisposeCore();
             if (this != null)
             {
-                Destroy(gameObject);
+                if (Application.isPlaying)
+                {
+                    Destroy(gameObject);
+                }
+                else
+                {
+                    DestroyImmediate(gameObject);
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #814

Hit the same issue @Nitero described in #814 — calling `Dispose()` on
a `LifetimeScope` outside Play Mode throws, because it always calls
`Destroy()`, which only works while the game is actually running. Ran
into this myself while writing an Editor test, and figured I'd fix it
properly instead of working around it locally.

`Dispose()` now checks `Application.isPlaying` and calls
`DestroyImmediate(gameObject)` when it's false. Play Mode behavior
(`Destroy`) is unchanged.

Didn't add an automated test — this repo's only test assembly
(`VContainer.Tests.asmdef`) isn't restricted to the Editor platform,
so Unity runs it under PlayMode, where `Application.isPlaying` is
always true and this branch would never actually be exercised.
Verified manually instead. Happy to add a proper Editor-only test
assembly in a follow-up if that'd be useful.