### PR TITLE
Fix incorrect diagnostic descriptor when multiple [Inject] methods are used

### DIFF
--- a/VContainer.SourceGenerator/Emitter.cs
+++ b/VContainer.SourceGenerator/Emitter.cs
@@ -150,7 +150,7 @@ static class Emitter
             {
                 var first = model.InjectMethods.First();
                 diagnostics.Add(new DiagnosticInfo(
-                    DiagnosticDescriptors.GenericsNotSupported,
+                    DiagnosticDescriptors.MultipleInjectMethodNotSupported,
                     first.Location ?? model.Location,
                     first.Name));
                 error = true;


### PR DESCRIPTION
Currently, if a class has multiple [Inject] methods, the source generator throws a GenericsNotSupported error. This PR adds a proper MultipleInjectMethodsNotSupported descriptor and fixes the typo in the injector model.